### PR TITLE
a2ui: a frame paid once per level, and a budget that only counted half

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4119,6 +4119,27 @@ was where the cost was. `fenestra_core::MAX_TREE_DEPTH` was measured against
 a 2 MiB stack; this cap was derived from that one without inheriting the
 measurement.
 
+**The margin, measured rather than assumed.** At `MAX_DEPTH` the renderer
+now needs somewhere between 1.5 and 2 MiB: it renders at 2048 KiB and
+overflows at 1536. So the default stack carries roughly a quarter to spare,
+which is a fix and not a comfort. `MAX_DEPTH` cannot be raised, and a
+recursive arm cannot grow much, without re-measuring —
+`renders_at_the_full_depth_cap` reads `FENESTRA_PROBE_STACK`, which is how
+those numbers were taken and how the next ones should be.
+
+Where the remaining cost is, is worth writing down because the obvious
+guess is wrong. Extracting `Button` — the largest recursive arm by a wide
+margin — into its own `#[inline(never)]` frame moved the threshold *not at
+all*, so the per-level cost is not dominated by match-arm locals once the
+leaves are gone. It is most likely the `Element` builder chain: every
+`.gap(..)`/`.children(..)` takes `self` by value and returns it, and an
+unoptimized build materializes each intermediate on the stack, so the frame
+scales with `size_of::<Element>()` times the length of the builder chain.
+That extraction was reverted rather than kept — a complication that buys
+nothing measured is worse than none — and shrinking `Element` or breaking
+the recursion into an explicit worklist is the lever if this ever needs
+more headroom.
+
 **One budget, or the bound is not a bound.** `children_of` charged template
 expansions to a render-wide budget and static child lists to nothing at
 all, so the cheaper amplifier was the unbounded one — a static list needs no

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4145,9 +4145,33 @@ expansions to a render-wide budget and static child lists to nothing at
 all, so the cheaper amplifier was the unbounded one — a static list needs no
 data model to expand against. Three `Column`s naming the next one fifty
 times is 127 551 components from a kilobyte of JSON. Both arms now draw on
-one `MAX_RENDERED_CHILDREN`, through `Ctx::take_children`, because two
+one `MAX_RENDERED_CHILDREN`, charged per component in `render_by_id`
+via `Ctx::charge_child`, because two
 counters can be played against each other by alternating the kinds of child
 list.
+
+**A refusal is work too.** The per-component charge landed *after*
+`render_by_id`'s cycle, depth-cap and missing-component early returns —
+each of which builds a placeholder, which is an `Element` and two `String`s.
+That left the bound bypassable about a thousandfold: a `Column` naming one
+undefined id a thousand times costs a single charge and builds a thousand
+`[missing: ..]` placeholders, and every charged component can host another
+such list. Measured against that commit, 2 001 001 elements from 11 KB of
+JSON while the budget reported 1001 of 10 000 spent. The charge is the first
+thing the function does now. The general form: a bound on "components built"
+has to count everything the function can be made to allocate, not the
+subset that reaches the happy path.
+
+**`mailto:` has two halves, and only one was being read.** The field check
+discarded everything before `?`, so `mailto:victim@example.com%0D%0Aattach=…`
+— no query at all — returned safe without inspecting anything. The address
+is `pct-encoded`-capable exactly like the fields, so it smuggles a header
+just as well. Both halves are checked now. In the other direction, banning
+CR/LF in *every* field was too much: RFC 6068 §6.1's own example is
+`?body=send%20current-issue%0D%0Asend%20index`, where `%0D%0A` is how the
+spec spells a newline in a body. A body cannot inject a header — it is the
+payload — so the ban applies to the fields that become headers and not to
+`body`.
 
 **An allowlist, or you are enumerating the attacker's options.**
 `mailto:` URLs were checked against a blocklist of `attach` and

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4080,3 +4080,67 @@ caller who masks all but one pixel and calls twice can read that pixel, and
 repeat. That is inherent in answering "how different are these?" at all.
 What it means is that `BaselineRoot` is not hardening layered around the
 underlay fix — it is the half that scales, and the docs say so now.
+
+## The frame you pay for once per level (2026-08-13)
+
+An adversarial pass over the A2UI renderer, and the finding that mattered
+was not the one it went looking for.
+
+**Rendering aborted the process at seven levels of nesting.**
+`render_by_id -> render_component -> children_of -> render_by_id` is a
+recursive cycle, so `render_component`'s stack frame is paid once per level
+of component nesting. It was a single `match` over all nineteen component
+kinds, and an unoptimized build gives such a frame room for every arm's
+locals at once — arms do not share slots without optimization. So every
+level cost what the *largest* arm needed, and the largest arms
+(`ChoicePicker`, `Slider`, `DateTimeInput`) are leaves that cannot appear
+on the recursive path at all.
+
+Measured on a 2 MiB stack — the `std::thread` and tokio blocking-pool
+default, which is what the MCP server renders on — a strictly linear chain
+of `Column`s overflowed at seven. `MAX_DEPTH` permits sixteen. Seven is not
+an attack: a Card inside a List inside a Tab is already half of it. And a
+stack overflow aborts rather than unwinding, so this was `SIGABRT` for the
+whole server from about seven hundred bytes of JSON, with no note and
+nothing to catch.
+
+`render_component` now holds only the kinds that recurse; every leaf kind
+moved to `render_leaf`, which is `#[inline(never)]` so its locals get a
+frame of their own at the bottom of the recursion instead of at every level
+of it. The full sixteen-level cap now renders on an explicitly 2 MiB
+thread, which is what `renders_at_the_full_depth_cap` pins — on its own
+thread, because the harness's main thread is 8 MiB and would have hidden
+the bug for another four levels.
+
+The general shape is worth keeping: `MAX_DEPTH`'s own doc reasoned about
+the *element tree* it produces staying inside `fenestra_core::MAX_TREE_DEPTH`,
+which was true, and said nothing about the renderer's own recursion, which
+was where the cost was. `fenestra_core::MAX_TREE_DEPTH` was measured against
+a 2 MiB stack; this cap was derived from that one without inheriting the
+measurement.
+
+**One budget, or the bound is not a bound.** `children_of` charged template
+expansions to a render-wide budget and static child lists to nothing at
+all, so the cheaper amplifier was the unbounded one — a static list needs no
+data model to expand against. Three `Column`s naming the next one fifty
+times is 127 551 components from a kilobyte of JSON. Both arms now draw on
+one `MAX_RENDERED_CHILDREN`, through `Ctx::take_children`, because two
+counters can be played against each other by alternating the kinds of child
+list.
+
+**An allowlist, or you are enumerating the attacker's options.**
+`mailto:` URLs were checked against a blocklist of `attach` and
+`attachment`. RFC 6068 writes `hfname` as `*qchar` with `pct-encoded` among
+the `qchar`s, so a conforming client decodes the name before acting on it
+and `%61ttach` is `attach` — invisible to a literal comparison, as is every
+vendor spelling nobody enumerated. The check now percent-decodes and
+compares against the header fields a generated link legitimately needs.
+This is the same argument `OPENABLE_SCHEMES` already makes one layer out;
+it should have been made here at the same time.
+
+**A guarantee at one call site is a property of the call graph.**
+`A2uiSignal::OpenUrl` documents that its URL is safe to hand to a platform
+opener, but the check lived only where the renderer resolved an action, and
+`A2uiMsg::OpenUrl` is a public variant a host can build, replay from a log,
+or round-trip through its own message type. `Surface::handle` re-checks it,
+so the promise belongs to the type.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## Unreleased
+
+An adversarial pass over the A2UI renderer. One crash, one unbounded
+expansion, and two checks that were narrower than the thing they guarded.
+
+### Fixed
+
+- **Rendering aborted the process at seven levels of nesting.**
+  `render_component` was one `match` over all nineteen component kinds, and
+  it sits on the `render_by_id -> render_component -> children_of ->
+  render_by_id` cycle — so its frame was paid once per level, sized for
+  whichever arm needed most, and the largest arms are leaves that never
+  recurse. On a 2 MiB stack (the `std::thread` and tokio blocking-pool
+  default, which is what the MCP server renders on) a plain chain of
+  `Column`s overflowed at seven levels, against a `MAX_DEPTH` of sixteen.
+  Seven is an ordinary surface, not an attack — a Card in a List in a Tab
+  is half of it — and a stack overflow aborts instead of unwinding, so it
+  was `SIGABRT` for the whole server from ~700 bytes of JSON, uncatchable
+  and unreported. The leaf kinds moved to an `#[inline(never)]`
+  `render_leaf`, so their locals get one frame at the bottom of the
+  recursion rather than a share of every level; the full cap now renders on
+  a 2 MiB thread.
+- **Static child lists were charged to no budget.** `children_of` metered
+  template expansions and let static lists expand freely — the cheaper
+  amplifier of the two, since a static list needs no data model. Three
+  `Column`s naming the next one fifty times is 127 551 components from a
+  kilobyte of JSON. Both arms now draw on one `MAX_RENDERED_CHILDREN`
+  (10 000), and dropped children record a `Truncated` note as before.
+- **A percent-encoded `mailto:` field bypassed the attachment check.** RFC
+  6068 percent-encodes header field names, so `%61ttach=` reaches a
+  conforming mail client as `attach=` and matched neither entry of the
+  `attach`/`attachment` blocklist — nor did any vendor spelling. The check
+  now decodes the name and compares it against the fields a generated link
+  legitimately uses (`to`, `cc`, `bcc`, `subject`, `body`, `in-reply-to`),
+  an allowlist for the same reason `OPENABLE_SCHEMES` is one.
+- **`Surface::handle` re-checks the URL scheme.** `A2uiSignal::OpenUrl`
+  promises its reader a scheme the host may launch, but the check ran only
+  where the renderer resolved an action, and `A2uiMsg::OpenUrl` is public —
+  a host can build one, or replay one. A refused URL now emits no signal
+  and records a `BlockedUrlScheme` note.
+
 ## 0.41.0 — 2026-08-10
 
 Three adversarial review rounds over the A2UI renderer, a security pass over

--- a/book/src/a2ui.md
+++ b/book/src/a2ui.md
@@ -125,10 +125,26 @@ knowing why, because it would not be if the string came through unchecked.
 scheme, so a stream that said `file:` or some installed app's custom scheme
 would be choosing a program to start on your user's machine — and a stream
 is only ever as trustworthy as whatever the agent writing it last read. So
-the renderer classifies the scheme when it resolves the action: `http`,
-`https` and `mailto` become `OpenUrl`, and everything else renders as a
-visible, inert control carrying a `blockedUrlScheme` note. By the time a URL
-reaches you it has been checked.
+the renderer classifies the URL: `http`, `https` and `mailto` can become
+`OpenUrl`, and everything else renders as a visible, inert control carrying
+a `blockedUrlScheme` note.
+
+An allowed scheme is not the same as an allowed URL, and `mailto:` is where
+that bites. Mail clients that honour an attachment field will stage a local
+file the user never chose into a pre-addressed message, so a `mailto:` gets
+through only if every header field it carries is one a generated link
+actually needs — `to`, `cc`, `bcc`, `subject`, `body`, `in-reply-to` — with
+no carriage return or newline in the values, which is how an extra header
+gets smuggled into a permitted one. Names and values are percent-decoded
+first, because `%61ttach` is `attach` by the time your mail client reads it.
+A well-formed `mailto:` can therefore come back inert; the note says so.
+
+The check runs twice: once when the renderer resolves the action, and again
+in `Surface::handle`, which will not emit the signal at all for a URL that
+fails. The second one matters because `A2uiMsg` is public — if you build an
+`OpenUrl` message yourself, or replay one from a log, it is still checked
+before it becomes a signal. By the time a URL reaches you it has been
+checked.
 
 Inputs bound to a path write straight back into the data model, so the
 next render reads what the user typed. `action_message` takes the

--- a/fenestra-a2ui/src/lib.rs
+++ b/fenestra-a2ui/src/lib.rs
@@ -78,5 +78,5 @@ pub mod surface;
 
 pub use messages::{Envelope, MessageStream, parse_stream};
 pub use note::{Note, NoteKind, NoteSeverity, any_broken};
-pub use render::{A2uiMsg, A2uiSignal, Rendered};
+pub use render::{A2uiMsg, A2uiSignal, OPENABLE_SCHEMES, Rendered, is_openable_url};
 pub use surface::{A2uiError, Client, Surface};

--- a/fenestra-a2ui/src/note.rs
+++ b/fenestra-a2ui/src/note.rs
@@ -45,7 +45,9 @@ pub enum NoteKind {
     UnknownIcon,
     /// A client-side function this build does not implement.
     UnimplementedFunction,
-    /// Output was cut short by a cap (template children).
+    /// Output was cut short by a cap — a child list (static or template)
+    /// past the per-expansion limit, a render past its component budget, or
+    /// the note list itself past its own.
     Truncated,
     /// A data-model write could not be applied; the model kept its
     /// previous value.

--- a/fenestra-a2ui/src/render.rs
+++ b/fenestra-a2ui/src/render.rs
@@ -227,6 +227,12 @@ pub enum A2uiSignal {
 /// and `sms:` are the obvious candidates), and an array bakes its length
 /// into the public type, so adding one would be a breaking change for no
 /// reason.
+///
+/// **This is necessary and not sufficient.** A `mailto:` whose scheme is
+/// on this list can still be refused, over its header fields — so a host
+/// re-validating a URL should call [`is_openable_url`], which is the whole
+/// rule, rather than testing membership here and believing it has
+/// reproduced the renderer's decision.
 pub const OPENABLE_SCHEMES: &[&str] = &["http", "https", "mailto"];
 
 /// The `mailto:` header fields a generated link may carry.
@@ -245,6 +251,29 @@ pub const OPENABLE_SCHEMES: &[&str] = &["http", "https", "mailto"];
 /// else — including a field this build simply has not heard of — makes the
 /// URL unopenable rather than being passed through and hoped about.
 const MAILTO_SAFE_FIELDS: &[&str] = &["to", "cc", "bcc", "subject", "body", "in-reply-to"];
+
+/// Whether `url` is something a host may hand to a platform opener — the
+/// renderer's own decision, in full.
+///
+/// Public because [`OPENABLE_SCHEMES`] on its own is a trap for the host
+/// that tries to re-derive this. A scheme test alone accepts
+/// `mailto:a@b?%61ttach=/Users/u/.ssh/id_rsa`, which this refuses; the
+/// scheme is necessary and not sufficient, and the rest of the rule lives
+/// in private constants a caller cannot see. Any host re-validating a URL
+/// it replayed, logged, or built itself should call this rather than
+/// reimplement it and drift.
+///
+/// The rules: the scheme must be one of [`OPENABLE_SCHEMES`]; and a
+/// `mailto:` may carry only the header fields a generated link needs, with
+/// no CR or LF in their values. Names and values are percent-decoded
+/// first. A URL with no scheme at all is refused too — `open(1)` and
+/// `xdg-open` both treat a bare path as a local file, so a "relative" URL
+/// is a `file:` in disguise, and a surface meaning to link to the web can
+/// say so.
+#[must_use]
+pub fn is_openable_url(url: &str) -> bool {
+    is_openable(url)
+}
 
 /// Whether `url` is something the host may hand to a platform opener.
 ///
@@ -587,6 +616,16 @@ impl Surface {
     /// Returns every signal the message produced, in order — usually none
     /// or one, but an [`A2uiMsg::Many`] (a Modal trigger that is also a
     /// Button) can produce several.
+    ///
+    /// # Where this records its notes
+    ///
+    /// On the *surface* ([`Surface::notes`]), not on the [`Rendered`] value
+    /// from the last [`Surface::render`] — the two lists are disjoint and
+    /// stay that way on purpose, since render notes are rebuilt every frame
+    /// and these accumulate across interactions. A caller checking only
+    /// `Rendered::notes` will not see that an `OpenUrl` was refused here.
+    /// Read both, as `fenestra_render::render_a2ui` does; `any_broken` over
+    /// the concatenation is the honest one-line check.
     #[must_use = "these are the effects the host must carry out; dropping them silently discards \
                   every agent-bound event the interaction produced"]
     pub fn handle(&mut self, msg: A2uiMsg) -> Vec<A2uiSignal> {
@@ -1816,7 +1855,7 @@ fn render_component(
                     id,
                     NoteKind::Unreachable,
                     "button has no action it can carry out and opens nothing; rendered as a \
-                     disabled control",
+                         disabled control",
                 );
             }
             match label {

--- a/fenestra-a2ui/src/render.rs
+++ b/fenestra-a2ui/src/render.rs
@@ -29,8 +29,13 @@ const MAX_DEPTH: usize = 16;
 /// name it either this way or with the bare id `basic`.
 const BASIC_CATALOG_URL: &str = "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json";
 
-/// The most children one template expansion materializes.
-const MAX_TEMPLATE_CHILDREN: usize = 1000;
+/// The most children one child list materializes, template or static.
+///
+/// Shared by both arms of [`children_of`]. The template arm had it first;
+/// giving the static arm its own cap is what keeps one enormous list from
+/// spending the whole render's budget in document order and leaving every
+/// later sibling of the surface blank.
+const MAX_CHILDREN_PER_EXPANSION: usize = 1000;
 
 /// The most children one whole render materializes, from every source.
 ///
@@ -184,13 +189,27 @@ pub enum A2uiSignal {
     },
     /// Open a URL with the platform opener.
     ///
-    /// Safe to hand to `open(1)`, `xdg-open`, or the browser: the scheme is
-    /// one of [`OPENABLE_SCHEMES`], checked when the action was resolved.
-    /// A stream naming anything else never reaches here — it renders as an
-    /// inert control with a [`NoteKind::BlockedUrlScheme`] note — because
-    /// those openers launch whichever application registered the scheme,
-    /// and the stream that named it is only as trustworthy as whatever the
-    /// agent writing it last read.
+    /// Safe to hand to `open(1)`, `xdg-open`, or the browser, because those
+    /// openers launch whichever application registered the scheme, and the
+    /// stream that named it is only as trustworthy as whatever the agent
+    /// writing it last read.
+    ///
+    /// Two rules, not one. The scheme must be in [`OPENABLE_SCHEMES`]; and
+    /// a `mailto:` must additionally carry only the header fields a
+    /// generated link needs (`to`, `cc`, `bcc`, `subject`, `body`,
+    /// `in-reply-to`), with no CR or LF in their values — an allowed scheme
+    /// is not an allowed URL, since a mail client that honours an
+    /// attachment field will stage a local file the user never chose.
+    /// Field names and values are percent-decoded before either check.
+    ///
+    /// Both are enforced twice: where the renderer resolves the action (the
+    /// control renders visible but inert, with a
+    /// [`NoteKind::BlockedUrlScheme`] note), and again in
+    /// [`Surface::handle`], which refuses to emit this signal at all for a
+    /// URL that fails them. The second is what makes the guarantee a
+    /// property of this type rather than of the renderer's call graph:
+    /// [`A2uiMsg::OpenUrl`] is public, so a host can build one, replay one
+    /// from a log, or round-trip one through its own message type.
     OpenUrl(
         /// The URL, scheme-checked.
         String,
@@ -274,12 +293,19 @@ fn mailto_fields_are_safe(rest: &str) -> bool {
         .split('&')
         .filter(|pair| !pair.is_empty())
         .all(|pair| {
-            let raw = pair.split('=').next().unwrap_or(pair);
-            let name = percent_decode(raw);
-            let name = name.trim();
-            MAILTO_SAFE_FIELDS
+            let (raw_name, raw_value) = pair.split_once('=').unwrap_or((pair, ""));
+            let name = percent_decode(raw_name);
+            let permitted = MAILTO_SAFE_FIELDS
                 .iter()
-                .any(|f| name.eq_ignore_ascii_case(f))
+                .any(|f| name.trim().eq_ignore_ascii_case(f));
+            // Naming a safe field is not enough: these values are written
+            // into message headers, and RFC 6068 §7 warns that a client
+            // doing so without sanitizing can be made to emit headers the
+            // URL never listed. A decoded CR or LF in `subject` is how
+            // `attach` gets added behind an allowlist that only ever
+            // inspected names — the encoded-value twin of the encoded-name
+            // hole this allowlist replaced.
+            permitted && !percent_decode(raw_value).contains(['\r', '\n'])
         })
 }
 
@@ -430,19 +456,35 @@ impl Ctx<'_> {
             .clone()
     }
 
-    /// Charges `wanted` children to the render-wide budget, returning how
-    /// many of them may actually be built.
+    /// Charges one component to the render-wide budget, returning whether
+    /// it may be built.
     ///
-    /// Both arms of [`children_of`] go through here rather than reading and
-    /// writing the cell themselves: the bound is on the *total*, so a
-    /// second call site that forgot to charge its children — which is
-    /// exactly how the static arm came to be unbounded — silently removes
-    /// the guarantee for every other one.
-    fn take_children(&self, wanted: usize) -> usize {
+    /// Called from [`render_by_id`] and nowhere else, because that is the
+    /// one function every materialized component passes through. Charging
+    /// at the *container* instead — which the first cut of this budget did,
+    /// metering only [`children_of`] — bounds nothing, because `Card`,
+    /// `Tabs`, `Modal` and `Button` reach their children by calling
+    /// `render_by_id` directly. Each of those was an uncharged multiplier
+    /// on top of a charged one: a `Card` chain multiplies the ceiling by
+    /// its depth, and a `Modal` (trigger *and* content) by two per level.
+    /// A bound with four ways around it is not a bound, and the way to stop
+    /// writing a fifth is to charge where the work actually happens.
+    fn charge_child(&self) -> bool {
         let budget = self.child_budget.get();
-        let allowed = wanted.min(budget);
-        self.child_budget.set(budget - allowed);
-        allowed
+        if budget == 0 {
+            return false;
+        }
+        self.child_budget.set(budget - 1);
+        true
+    }
+
+    /// How many more components this render may materialize.
+    ///
+    /// Read-only: [`children_of`] uses it to avoid walking a hundred
+    /// thousand ids to build a hundred thousand refusals. The charge itself
+    /// happens in [`Ctx::charge_child`].
+    fn remaining_children(&self) -> usize {
+        self.child_budget.get()
     }
 
     /// Reports children dropped to stay inside the render-wide budget.
@@ -1426,6 +1468,20 @@ fn render_by_id(ctx: &Ctx, id: &str, scope: Option<&str>, depth: usize) -> Eleme
         );
         return placeholder(format!("[missing: {id}]"), ctx.theme);
     };
+    // Every materialized component is charged here, which is the only place
+    // all of them pass through. See [`Ctx::charge_child`] for why charging
+    // at the container instead left four ways around the bound.
+    if !ctx.charge_child() {
+        ctx.note(
+            id,
+            NoteKind::Truncated,
+            format!(
+                "this render reached its {MAX_RENDERED_CHILDREN}-component budget; \
+                 {id:?} and anything below it were not built (nested containers multiply)"
+            ),
+        );
+        return placeholder(format!("[budget: {id}]"), ctx.theme);
+    }
     ctx.path_stack.borrow_mut().push(id.to_owned());
     let el = render_component(ctx, component, scope, depth);
     ctx.path_stack.borrow_mut().pop();
@@ -1445,13 +1501,29 @@ fn children_of(
 ) -> Vec<Element<A2uiMsg>> {
     match list {
         ChildList::Static(ids) => {
-            // Charged to the same budget as a template expansion. A static
-            // list is enumerated in the stream, so its own length is bounded
-            // by the document — but the *product* across nesting levels is
-            // not, and that is what this bounds.
-            let allowed = ctx.take_children(ids.len());
-            if allowed < ids.len() {
-                ctx.note_children_dropped(id, ids.len() - allowed);
+            // The same two caps a template expansion gets, and for the same
+            // reasons. The per-expansion one keeps a single enormous list
+            // from spending the whole render's budget in document order and
+            // leaving every later sibling blank; the render-wide one bounds
+            // the product across nesting levels. Only the first is applied
+            // here — the budget itself is charged per component in
+            // `render_by_id`; this merely avoids walking a list to build
+            // refusals nobody can see.
+            if ids.len() > MAX_CHILDREN_PER_EXPANSION {
+                ctx.note(
+                    id,
+                    NoteKind::Truncated,
+                    format!(
+                        "{} static children exceed the cap ({MAX_CHILDREN_PER_EXPANSION}); \
+                         extra children dropped",
+                        ids.len()
+                    ),
+                );
+            }
+            let wanted = ids.len().min(MAX_CHILDREN_PER_EXPANSION);
+            let allowed = wanted.min(ctx.remaining_children());
+            if allowed < wanted {
+                ctx.note_children_dropped(id, wanted - allowed);
             }
             ids[..allowed]
                 .iter()
@@ -1467,12 +1539,13 @@ fn children_of(
                 );
                 return Vec::new();
             };
-            if items.len() > MAX_TEMPLATE_CHILDREN {
+            if items.len() > MAX_CHILDREN_PER_EXPANSION {
                 ctx.note(
                     id,
                     NoteKind::Truncated,
                     format!(
-                        "{} template items exceed the cap ({MAX_TEMPLATE_CHILDREN}); extra items dropped",
+                        "{} template items exceed the cap ({MAX_CHILDREN_PER_EXPANSION}); \
+                         extra items dropped",
                         items.len()
                     ),
                 );
@@ -1480,8 +1553,8 @@ fn children_of(
             // Per-expansion cap, then the render-wide one: nesting templates
             // over the same list multiplies, and each level alone is
             // perfectly reasonable.
-            let wanted = items.len().min(MAX_TEMPLATE_CHILDREN);
-            let allowed = ctx.take_children(wanted);
+            let wanted = items.len().min(MAX_CHILDREN_PER_EXPANSION);
+            let allowed = wanted.min(ctx.remaining_children());
             if allowed < wanted {
                 ctx.note_children_dropped(id, wanted - allowed);
             }
@@ -1544,10 +1617,6 @@ fn apply_flex(
     }
 }
 
-#[expect(
-    clippy::too_many_lines,
-    reason = "one arm per catalog component; splitting would scatter the mapping"
-)]
 /// Renders one component.
 ///
 /// Split in two, and the split is load-bearing rather than cosmetic. This
@@ -2187,6 +2256,20 @@ fn render_leaf(ctx: &Ctx, component: &Component, scope: Option<&str>) -> Element
             );
             placeholder(format!("[{name}]"), theme)
         }
+        // The container kinds, which `render_component` handles before it
+        // delegates here — so this arm is unreachable today.
+        //
+        // It degrades instead of asserting that, and the difference is the
+        // whole point. `render_component` dispatches containers explicitly
+        // and sends everything else here with a `_` arm, which means adding
+        // a `Kind` to the catalog compiles there and fails only *here*. The
+        // compiler therefore walks the next author straight to this arm,
+        // where the tidy-looking fix is to add the new name to the list —
+        // and an `unreachable!` would turn that into a process panic on any
+        // stream using the feature, in a crate whose premise is that
+        // agent-supplied input degrades with a note and never aborts.
+        // Rendering a placeholder makes the mistake cost a visible
+        // `[unmapped: id]` and a `broken` note instead.
         Kind::Row { .. }
         | Kind::Column { .. }
         | Kind::List { .. }
@@ -2194,7 +2277,14 @@ fn render_leaf(ctx: &Ctx, component: &Component, scope: Option<&str>) -> Element
         | Kind::Tabs { .. }
         | Kind::Modal { .. }
         | Kind::Button { .. } => {
-            unreachable!("container kinds are dispatched by render_component")
+            ctx.note(
+                id,
+                NoteKind::MalformedComponent,
+                "component kind reached the leaf renderer, which cannot map it; \
+                 it renders as a placeholder (a container kind is missing from \
+                 render_component's dispatch)",
+            );
+            placeholder(format!("[unmapped: {id}]"), theme)
         }
     }
 }

--- a/fenestra-a2ui/src/render.rs
+++ b/fenestra-a2ui/src/render.rs
@@ -32,14 +32,27 @@ const BASIC_CATALOG_URL: &str = "https://a2ui.org/specification/v0_9/catalogs/ba
 /// The most children one template expansion materializes.
 const MAX_TEMPLATE_CHILDREN: usize = 1000;
 
-/// The most template-generated children one whole render materializes.
+/// The most children one whole render materializes, from every source.
 ///
 /// Capping each expansion bounds a factor; this bounds the product. Real
 /// surfaces do not come close — an eagerly-built tree of ten thousand rows
 /// is already past what anyone would put on screen, and nothing here is
-/// virtualized — while a nested template over the same list reaches it in
+/// virtualized — while a nested container over the same list reaches it in
 /// three levels and would otherwise keep going.
-const MAX_TEMPLATE_TOTAL: usize = 10_000;
+///
+/// This counts *every* child [`children_of`] materializes, not only the
+/// ones a template generated. The first cut of this budget charged the
+/// template arm alone, which left the cheaper amplifier of the two running
+/// free: a static child list needs no data model to expand against, so
+/// eleven `Column`s naming the next one three times — under a kilobyte of
+/// JSON — built 265 720 components, and the same shape at `MAX_DEPTH`'s
+/// full 16 levels with a fan-out of ten is past 10^16. Cycle detection does
+/// not fire, because every level is a distinct component id, and
+/// `fenestra_core` guards element-tree *depth* rather than breadth, so
+/// nothing downstream caught it either. One budget over both arms is what
+/// makes the bound hold: two counters can be played against each other by
+/// alternating the kinds of child list.
+const MAX_RENDERED_CHILDREN: usize = 10_000;
 
 /// Identity for one piece of client-side UI state: which component, and —
 /// when it was rendered inside a template expansion — which item.
@@ -197,13 +210,22 @@ pub enum A2uiSignal {
 /// reason.
 pub const OPENABLE_SCHEMES: &[&str] = &["http", "https", "mailto"];
 
-/// `mailto:` query parameters that name a local file to attach.
+/// The `mailto:` header fields a generated link may carry.
 ///
-/// Not every mail client honours these, but enough have that it is a known
-/// way to turn "open a link" into "stage a file the user never chose into an
-/// outgoing message". They are the reason checking the scheme is not the
-/// same as checking the URL.
-const MAILTO_ATTACHMENT_PARAMS: &[&str] = &["attach", "attachment"];
+/// An allowlist, for the same reason [`OPENABLE_SCHEMES`] is one, and
+/// arrived at the same way. The first cut named the two fields known to
+/// stage a local file — `attach` and `attachment` — which is a blocklist,
+/// and it was wrong twice over: mail clients ship their own spellings
+/// (`x-mozilla-attach` and friends), and RFC 6068 writes `hfname` as
+/// `*qchar` with `pct-encoded` among the `qchar`s, so `%61ttach` is
+/// `attach` by the time a conforming client reads it and matched neither
+/// name. Enumerating what a link legitimately needs is finite; enumerating
+/// what a mail client might act on is not.
+///
+/// These are the fields RFC 6068 describes for composing a message. Anything
+/// else — including a field this build simply has not heard of — makes the
+/// URL unopenable rather than being passed through and hoped about.
+const MAILTO_SAFE_FIELDS: &[&str] = &["to", "cc", "bcc", "subject", "body", "in-reply-to"];
 
 /// Whether `url` is something the host may hand to a platform opener.
 ///
@@ -228,26 +250,79 @@ fn is_openable(url: &str) -> bool {
         return false;
     }
     // The scheme being allowed is not the end of it. A `mailto:` may carry
-    // an attachment parameter naming a path on the user's disk, which is the
-    // same "a stream chose a local file" problem the scheme check exists to
+    // header fields naming a path on the user's disk, which is the same
+    // "a stream chose a local file" problem the scheme check exists to
     // stop, one layer in.
     if scheme.eq_ignore_ascii_case("mailto") {
-        return !has_attachment_param(rest);
+        return mailto_fields_are_safe(rest);
     }
     true
 }
 
-/// Whether a `mailto:` body carries an attachment parameter.
-fn has_attachment_param(rest: &str) -> bool {
+/// Whether every header field in a `mailto:` body is one a generated link
+/// may carry (see [`MAILTO_SAFE_FIELDS`]).
+///
+/// A URL with no query carries no fields and is safe. An unparseable or
+/// unknown field fails closed: a name that percent-decodes to something
+/// containing its own `&` or `=` does not match any allowed field, so a
+/// stream cannot smuggle a second field inside the first one's name.
+fn mailto_fields_are_safe(rest: &str) -> bool {
     let Some((_, query)) = rest.split_once('?') else {
-        return false;
+        return true;
     };
-    query.split('&').any(|pair| {
-        let name = pair.split('=').next().unwrap_or(pair).trim();
-        MAILTO_ATTACHMENT_PARAMS
-            .iter()
-            .any(|p| name.eq_ignore_ascii_case(p))
-    })
+    query
+        .split('&')
+        .filter(|pair| !pair.is_empty())
+        .all(|pair| {
+            let raw = pair.split('=').next().unwrap_or(pair);
+            let name = percent_decode(raw);
+            let name = name.trim();
+            MAILTO_SAFE_FIELDS
+                .iter()
+                .any(|f| name.eq_ignore_ascii_case(f))
+        })
+}
+
+/// Percent-decodes a `mailto:` header field name.
+///
+/// RFC 6068 writes `hfname` as `*qchar` and includes `pct-encoded` among
+/// the `qchar`s, so the name a mail client acts on is the *decoded* one —
+/// `%61ttach` is `attach`. Matching the raw text let every encoded spelling
+/// through, which is the hole this closes.
+///
+/// A `%` that does not introduce two hex digits is passed through as a
+/// literal, exactly as a lenient client would read it; the result is
+/// compared against an allowlist, so anything this decodes oddly is refused
+/// rather than admitted. Invalid UTF-8 goes through
+/// [`String::from_utf8_lossy`] — a replacement character matches no ASCII
+/// field name, which is the direction to fail in.
+fn percent_decode(s: &str) -> String {
+    /// One hex digit as its value.
+    fn hex(b: u8) -> Option<u8> {
+        match b {
+            b'0'..=b'9' => Some(b - b'0'),
+            b'a'..=b'f' => Some(b - b'a' + 10),
+            b'A'..=b'F' => Some(b - b'A' + 10),
+            _ => None,
+        }
+    }
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        // `hi * 16 + lo` cannot overflow: both are at most 15.
+        if bytes[i] == b'%'
+            && i + 2 < bytes.len()
+            && let (Some(hi), Some(lo)) = (hex(bytes[i + 1]), hex(bytes[i + 2]))
+        {
+            out.push(hi * 16 + lo);
+            i += 3;
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
 }
 
 /// A rendered surface: the element tree plus render-time fidelity notes.
@@ -293,15 +368,17 @@ struct Ctx<'a> {
     /// anyway. The check has to win: it is the stream's own instruction not
     /// to act yet.
     blocked_trigger: std::cell::Cell<bool>,
-    /// How many more template-generated children this render may build.
+    /// How many more children this render may build, from any source.
     ///
-    /// [`MAX_TEMPLATE_CHILDREN`] bounds one expansion; this bounds their
-    /// product. An absolute template path is scope-invariant by design, so
-    /// nesting templates over the same list multiplies without ever
-    /// repeating a component id — which is what cycle detection watches
-    /// for. Four levels over a 30-item list is 810 000 elements from half a
-    /// kilobyte of JSON.
-    template_budget: std::cell::Cell<usize>,
+    /// [`MAX_TEMPLATE_CHILDREN`] bounds one template expansion; this bounds
+    /// the product of every nesting level, static lists included. An
+    /// absolute template path is scope-invariant by design, so nesting
+    /// templates over the same list multiplies without ever repeating a
+    /// component id — which is what cycle detection watches for. Four levels
+    /// over a 30-item list is 810 000 elements from half a kilobyte of JSON,
+    /// and a static child list does the same thing without needing a data
+    /// model at all. See [`MAX_RENDERED_CHILDREN`].
+    child_budget: std::cell::Cell<usize>,
     /// Compiled validation patterns, keyed by their source text.
     ///
     /// A template renders its component once per item, so a `regex` check
@@ -351,6 +428,34 @@ impl Ctx<'_> {
             .entry(pattern.to_owned())
             .or_insert_with(|| checks::compile_pattern(pattern))
             .clone()
+    }
+
+    /// Charges `wanted` children to the render-wide budget, returning how
+    /// many of them may actually be built.
+    ///
+    /// Both arms of [`children_of`] go through here rather than reading and
+    /// writing the cell themselves: the bound is on the *total*, so a
+    /// second call site that forgot to charge its children — which is
+    /// exactly how the static arm came to be unbounded — silently removes
+    /// the guarantee for every other one.
+    fn take_children(&self, wanted: usize) -> usize {
+        let budget = self.child_budget.get();
+        let allowed = wanted.min(budget);
+        self.child_budget.set(budget - allowed);
+        allowed
+    }
+
+    /// Reports children dropped to stay inside the render-wide budget.
+    fn note_children_dropped(&self, id: &str, dropped: usize) {
+        self.note(
+            id,
+            NoteKind::Truncated,
+            format!(
+                "this render has materialized {} of {MAX_RENDERED_CHILDREN} children; \
+                 {dropped} more here were dropped (nested containers multiply)",
+                MAX_RENDERED_CHILDREN - self.child_budget.get(),
+            ),
+        );
     }
 
     /// Reports an enum string the catalog does not define.
@@ -412,7 +517,7 @@ impl Surface {
             theme,
             armed_triggers: std::cell::RefCell::new(Vec::new()),
             blocked_trigger: std::cell::Cell::new(false),
-            template_budget: std::cell::Cell::new(MAX_TEMPLATE_TOTAL),
+            child_budget: std::cell::Cell::new(MAX_RENDERED_CHILDREN),
             patterns: std::cell::RefCell::new(std::collections::HashMap::new()),
             notes: std::cell::RefCell::new(Vec::new()),
             path_stack: std::cell::RefCell::new(Vec::new()),
@@ -495,7 +600,32 @@ impl Surface {
                 data_model: self.send_data_model.then(|| self.data.clone()),
                 source_id,
             }],
-            A2uiMsg::OpenUrl(url) => vec![A2uiSignal::OpenUrl(url)],
+            A2uiMsg::OpenUrl(url) => {
+                // Checked again here, not only where the action was
+                // resolved. [`A2uiSignal::OpenUrl`] promises its reader that
+                // the URL is safe to hand to a platform opener, and that
+                // promise is what a host acts on — but `A2uiMsg` is public,
+                // so a host holding one it built itself (or replayed from a
+                // log, or round-tripped through its own message type) can
+                // reach this arm without the renderer ever having looked at
+                // the string. One check at the point of construction is a
+                // property of today's call graph; a check here is a property
+                // of the type.
+                if is_openable(&url) {
+                    vec![A2uiSignal::OpenUrl(url)]
+                } else {
+                    self.push_note(Note::new(
+                        "",
+                        NoteKind::BlockedUrlScheme,
+                        format!(
+                            "openUrl {} is not a scheme this renderer will open; \
+                             the signal was not emitted",
+                            quoted(&url)
+                        ),
+                    ));
+                    Vec::new()
+                }
+            }
             A2uiMsg::OpenModal(id) => {
                 self.ui.open_modals.insert(id);
                 Vec::new()
@@ -1314,10 +1444,20 @@ fn children_of(
     depth: usize,
 ) -> Vec<Element<A2uiMsg>> {
     match list {
-        ChildList::Static(ids) => ids
-            .iter()
-            .map(|cid| render_by_id(ctx, cid, scope, depth + 1))
-            .collect(),
+        ChildList::Static(ids) => {
+            // Charged to the same budget as a template expansion. A static
+            // list is enumerated in the stream, so its own length is bounded
+            // by the document — but the *product* across nesting levels is
+            // not, and that is what this bounds.
+            let allowed = ctx.take_children(ids.len());
+            if allowed < ids.len() {
+                ctx.note_children_dropped(id, ids.len() - allowed);
+            }
+            ids[..allowed]
+                .iter()
+                .map(|cid| render_by_id(ctx, cid, scope, depth + 1))
+                .collect()
+        }
         ChildList::Template { component_id, path } => {
             let Some(Value::Array(items)) = lookup(ctx.surface, path, scope) else {
                 ctx.note(
@@ -1341,20 +1481,9 @@ fn children_of(
             // over the same list multiplies, and each level alone is
             // perfectly reasonable.
             let wanted = items.len().min(MAX_TEMPLATE_CHILDREN);
-            let budget = ctx.template_budget.get();
-            let allowed = wanted.min(budget);
-            ctx.template_budget.set(budget - allowed);
+            let allowed = ctx.take_children(wanted);
             if allowed < wanted {
-                ctx.note(
-                    id,
-                    NoteKind::Truncated,
-                    format!(
-                        "this render has materialized {} of {MAX_TEMPLATE_TOTAL} template \
-                         children; {} more here were dropped (nested templates multiply)",
-                        MAX_TEMPLATE_TOTAL - ctx.template_budget.get(),
-                        wanted - allowed
-                    ),
-                );
+                ctx.note_children_dropped(id, wanted - allowed);
             }
             // The canonical join: an absolute template path stays absolute
             // even inside a collection scope (a naive `{scope}/{path}` join
@@ -1419,12 +1548,250 @@ fn apply_flex(
     clippy::too_many_lines,
     reason = "one arm per catalog component; splitting would scatter the mapping"
 )]
+/// Renders one component.
+///
+/// Split in two, and the split is load-bearing rather than cosmetic. This
+/// function holds only the kinds that recurse into children; every leaf
+/// kind lives in [`render_leaf`], which is `#[inline(never)]` so that its
+/// locals get a frame of their own.
+///
+/// The reason is that `render_by_id` -> `render_component` ->
+/// `children_of` -> `render_by_id` is a recursive cycle, so whatever this
+/// frame costs is paid once per level of component nesting. With all
+/// nineteen kinds in one `match`, an unoptimized build gives the frame
+/// room for every arm's locals at once — the arms do not share slots
+/// without optimization — and the biggest arms (`ChoicePicker`, `Slider`,
+/// `DateTimeInput`) are leaves that can never be on the recursive path at
+/// all. Measured on a 2 MiB stack (the `std::thread` and tokio
+/// blocking-pool default, which is what the MCP server renders on), that
+/// arrangement overflowed at **seven** levels of nesting — well under this
+/// module's own `MAX_DEPTH`, and well under what an ordinary surface
+/// nests: a Card in a List in a Tab is already half of it. The overflow
+/// aborts the process rather than unwinding, so it took the whole server
+/// with it and no note or error could describe what happened.
+///
+/// Keeping the leaves off the recursive path is what buys the depth back.
+/// If a new *container* kind is added, it belongs here; if a new leaf is
+/// added, it belongs in `render_leaf`, and putting it in the wrong one is
+/// a stack regression rather than a compile error — which is what
+/// `renders_at_the_full_depth_cap` is watching for.
 fn render_component(
     ctx: &Ctx,
     component: &Component,
     scope: Option<&str>,
     depth: usize,
 ) -> Element<A2uiMsg> {
+    let id = component.id.as_str();
+    match &component.kind {
+        Kind::Row {
+            children,
+            justify,
+            align,
+        } => {
+            let kids = children_of(ctx, id, children, scope, depth);
+            apply_flex(
+                row().gap(8.0).children(kids),
+                justify.as_deref(),
+                align.as_deref(),
+                id,
+                ctx,
+            )
+        }
+        Kind::Column {
+            children,
+            justify,
+            align,
+        } => {
+            let kids = children_of(ctx, id, children, scope, depth);
+            apply_flex(
+                col().gap(8.0).children(kids),
+                justify.as_deref(),
+                align.as_deref(),
+                id,
+                ctx,
+            )
+        }
+        Kind::List {
+            children,
+            direction,
+            align,
+        } => {
+            let kids = children_of(ctx, id, children, scope, depth);
+            if let Some(d) = direction.as_deref()
+                && !matches!(d, "horizontal" | "vertical")
+            {
+                ctx.note_unknown_variant(id, "direction", d, "a vertical list");
+            }
+            let horizontal = direction.as_deref() == Some("horizontal");
+            let el = if horizontal {
+                row().gap(8.0).children(kids).scroll_x()
+            } else {
+                col().gap(8.0).children(kids).scroll_y()
+            };
+            apply_flex(el.id(id), None, align.as_deref(), id, ctx)
+        }
+        Kind::Card { child } => card()
+            .child(render_by_id(ctx, child, scope, depth + 1))
+            .p(16.0),
+        Kind::Tabs { tabs: items } => {
+            let labels: Vec<String> = items
+                .iter()
+                .map(|t| resolve_value(ctx, id, &t.title, scope))
+                .collect();
+            let tabs_key = ui_key(id, scope);
+            let active = ctx
+                .surface
+                .ui
+                .active_tabs
+                .get(&tabs_key)
+                .copied()
+                .unwrap_or(0)
+                .min(items.len().saturating_sub(1));
+            let strip = tabs(active, labels, move |index| A2uiMsg::SelectTab {
+                key: tabs_key.clone(),
+                index,
+            });
+            let mut container = col().gap(8.0).child(strip);
+            if let Some(tab) = items.get(active) {
+                container = container.child(render_by_id(ctx, &tab.child, scope, depth + 1));
+            }
+            container
+        }
+        Kind::Modal { trigger, content } => {
+            let modal_key = ui_key(id, scope);
+            let open = ctx.surface.ui.open_modals.contains(&modal_key);
+            // Arm the trigger only while it is genuinely being rendered as
+            // one, so a Modal nothing reaches cannot vouch for a button it
+            // will never wrap. Popped straight after: a trigger that is
+            // itself inside another Modal's trigger must not stay armed for
+            // its siblings.
+            ctx.armed_triggers.borrow_mut().push(trigger.clone());
+            ctx.blocked_trigger.set(false);
+            let trigger_el = render_by_id(ctx, trigger, scope, depth + 1);
+            ctx.armed_triggers.borrow_mut().pop();
+            // A trigger whose own checks fail stays as rendered: disabled,
+            // showing why. Arming it would hand the press to the wrapper
+            // around the dead button and open the dialog regardless.
+            let opener = if ctx.blocked_trigger.replace(false) {
+                trigger_el
+            } else {
+                open_modal_trigger(ctx, id, &modal_key, trigger_el)
+            };
+            if open {
+                col().children((
+                    opener,
+                    modal("")
+                        .child(render_by_id(ctx, content, scope, depth + 1))
+                        .on_close(A2uiMsg::CloseModal(modal_key.clone())),
+                ))
+            } else {
+                opener
+            }
+        }
+        Kind::Button {
+            child,
+            variant,
+            action,
+            checks,
+        } => {
+            let failure = evaluate_checks(ctx, id, checks, scope);
+            // Extract a text label when the child is a Text component; any
+            // other child renders inside an icon button.
+            let child_component = ctx.surface.components.get(child);
+            let label = match child_component.map(|c| &c.kind) {
+                Some(Kind::Text { text: content, .. }) => {
+                    Some(resolve_value(ctx, id, content, scope))
+                }
+                _ => None,
+            };
+            let kit_variant = match variant.as_deref() {
+                Some("primary") => ButtonVariant::Primary,
+                Some("borderless") => ButtonVariant::Ghost,
+                other => {
+                    if let Some(v) = other {
+                        ctx.note_unknown_variant(id, "variant", v, "a secondary button");
+                    }
+                    ButtonVariant::Secondary
+                }
+            };
+            let msg = action.as_ref().map(|a| action_msg(ctx, id, a, scope));
+            // Only the Modal currently rendering *this* component as its
+            // trigger counts. `last()` is the innermost one, which is the
+            // Modal that will wrap what we are building right now.
+            let opens_a_modal = ctx
+                .armed_triggers
+                .borrow()
+                .last()
+                .is_some_and(|armed| armed == id);
+            // An action that resolved to nothing leaves the button just as
+            // dead as no action at all — `Ignored` is what an unimplemented
+            // function or an unresolvable openUrl becomes. Both answers to
+            // "can this button do anything?" have to be the same, or the
+            // note below is true of one path and a lie about the other.
+            let inert = !opens_a_modal && matches!(msg, None | Some(A2uiMsg::Ignored));
+            // A failing check is the whole point of putting one on a
+            // button: it must not carry out its action. Decided here, before
+            // the widget is built, because the kit bakes disabled styling in
+            // at build time.
+            let blocked = failure.is_some();
+            if blocked && opens_a_modal {
+                ctx.blocked_trigger.set(true);
+            }
+            // A blocked URL scheme already recorded *why* this button does
+            // nothing, and it is not "no action it can carry out" — the
+            // action was understood and deliberately refused. Two Broken
+            // notes for one cause, the second of them untrue, is worse than
+            // one.
+            if inert && !ctx.noted(id, NoteKind::BlockedUrlScheme) {
+                ctx.note(
+                    id,
+                    NoteKind::Unreachable,
+                    "button has no action it can carry out and opens nothing; rendered as a \
+                     disabled control",
+                );
+            }
+            match label {
+                Some(label) => {
+                    let mut b = button(label).variant(kit_variant);
+                    // A modal trigger has something to do even without an
+                    // action of its own, so it must not be *built* disabled
+                    // — see `Ctx::armed_triggers`.
+                    if inert || blocked {
+                        b = b.disabled(true);
+                    } else if let Some(m) = msg {
+                        b = b.on_click(m);
+                    }
+                    labeled_control(None, b.into(), failure, ctx.theme)
+                }
+                None => {
+                    let inner = render_by_id(ctx, child, scope, depth + 1);
+                    let mut b = icon_button(inner);
+                    // Same rule as the labeled branch — an inert button
+                    // must *look* inert, or the note above is a lie and the
+                    // user presses a live-looking control that does nothing.
+                    if inert || blocked {
+                        b = b.disabled(true);
+                    } else if let Some(m) = msg {
+                        b = b.on_click(m);
+                    }
+                    labeled_control(None, b.into(), failure, ctx.theme)
+                }
+            }
+        }
+        // Every other kind is a leaf: it renders no children, so it can
+        // never be on the recursive path, and its locals do not belong in
+        // a frame that is paid for once per level.
+        _ => render_leaf(ctx, component, scope),
+    }
+}
+
+/// The component kinds that render no children.
+///
+/// `#[inline(never)]` on purpose: see [`render_component`]. Inlined back
+/// into the dispatcher, this function's locals would rejoin the recursive
+/// frame and undo the fix.
+#[inline(never)]
+fn render_leaf(ctx: &Ctx, component: &Component, scope: Option<&str>) -> Element<A2uiMsg> {
     let id = component.id.as_str();
     let theme = ctx.theme;
     match &component.kind {
@@ -1547,111 +1914,6 @@ fn render_component(
             );
             placeholder(format!("[audio: {}]", truncate_label(&label, 48)), theme)
         }
-        Kind::Row {
-            children,
-            justify,
-            align,
-        } => {
-            let kids = children_of(ctx, id, children, scope, depth);
-            apply_flex(
-                row().gap(8.0).children(kids),
-                justify.as_deref(),
-                align.as_deref(),
-                id,
-                ctx,
-            )
-        }
-        Kind::Column {
-            children,
-            justify,
-            align,
-        } => {
-            let kids = children_of(ctx, id, children, scope, depth);
-            apply_flex(
-                col().gap(8.0).children(kids),
-                justify.as_deref(),
-                align.as_deref(),
-                id,
-                ctx,
-            )
-        }
-        Kind::List {
-            children,
-            direction,
-            align,
-        } => {
-            let kids = children_of(ctx, id, children, scope, depth);
-            if let Some(d) = direction.as_deref()
-                && !matches!(d, "horizontal" | "vertical")
-            {
-                ctx.note_unknown_variant(id, "direction", d, "a vertical list");
-            }
-            let horizontal = direction.as_deref() == Some("horizontal");
-            let el = if horizontal {
-                row().gap(8.0).children(kids).scroll_x()
-            } else {
-                col().gap(8.0).children(kids).scroll_y()
-            };
-            apply_flex(el.id(id), None, align.as_deref(), id, ctx)
-        }
-        Kind::Card { child } => card()
-            .child(render_by_id(ctx, child, scope, depth + 1))
-            .p(16.0),
-        Kind::Tabs { tabs: items } => {
-            let labels: Vec<String> = items
-                .iter()
-                .map(|t| resolve_value(ctx, id, &t.title, scope))
-                .collect();
-            let tabs_key = ui_key(id, scope);
-            let active = ctx
-                .surface
-                .ui
-                .active_tabs
-                .get(&tabs_key)
-                .copied()
-                .unwrap_or(0)
-                .min(items.len().saturating_sub(1));
-            let strip = tabs(active, labels, move |index| A2uiMsg::SelectTab {
-                key: tabs_key.clone(),
-                index,
-            });
-            let mut container = col().gap(8.0).child(strip);
-            if let Some(tab) = items.get(active) {
-                container = container.child(render_by_id(ctx, &tab.child, scope, depth + 1));
-            }
-            container
-        }
-        Kind::Modal { trigger, content } => {
-            let modal_key = ui_key(id, scope);
-            let open = ctx.surface.ui.open_modals.contains(&modal_key);
-            // Arm the trigger only while it is genuinely being rendered as
-            // one, so a Modal nothing reaches cannot vouch for a button it
-            // will never wrap. Popped straight after: a trigger that is
-            // itself inside another Modal's trigger must not stay armed for
-            // its siblings.
-            ctx.armed_triggers.borrow_mut().push(trigger.clone());
-            ctx.blocked_trigger.set(false);
-            let trigger_el = render_by_id(ctx, trigger, scope, depth + 1);
-            ctx.armed_triggers.borrow_mut().pop();
-            // A trigger whose own checks fail stays as rendered: disabled,
-            // showing why. Arming it would hand the press to the wrapper
-            // around the dead button and open the dialog regardless.
-            let opener = if ctx.blocked_trigger.replace(false) {
-                trigger_el
-            } else {
-                open_modal_trigger(ctx, id, &modal_key, trigger_el)
-            };
-            if open {
-                col().children((
-                    opener,
-                    modal("")
-                        .child(render_by_id(ctx, content, scope, depth + 1))
-                        .on_close(A2uiMsg::CloseModal(modal_key.clone())),
-                ))
-            } else {
-                opener
-            }
-        }
         Kind::Divider { axis } => match axis.as_deref() {
             Some("vertical") => div().w(1.0).h_full().bg(theme.border_subtle),
             Some("horizontal") | None => divider(),
@@ -1660,96 +1922,6 @@ fn render_component(
                 divider()
             }
         },
-        Kind::Button {
-            child,
-            variant,
-            action,
-            checks,
-        } => {
-            let failure = evaluate_checks(ctx, id, checks, scope);
-            // Extract a text label when the child is a Text component; any
-            // other child renders inside an icon button.
-            let child_component = ctx.surface.components.get(child);
-            let label = match child_component.map(|c| &c.kind) {
-                Some(Kind::Text { text: content, .. }) => {
-                    Some(resolve_value(ctx, id, content, scope))
-                }
-                _ => None,
-            };
-            let kit_variant = match variant.as_deref() {
-                Some("primary") => ButtonVariant::Primary,
-                Some("borderless") => ButtonVariant::Ghost,
-                other => {
-                    if let Some(v) = other {
-                        ctx.note_unknown_variant(id, "variant", v, "a secondary button");
-                    }
-                    ButtonVariant::Secondary
-                }
-            };
-            let msg = action.as_ref().map(|a| action_msg(ctx, id, a, scope));
-            // Only the Modal currently rendering *this* component as its
-            // trigger counts. `last()` is the innermost one, which is the
-            // Modal that will wrap what we are building right now.
-            let opens_a_modal = ctx
-                .armed_triggers
-                .borrow()
-                .last()
-                .is_some_and(|armed| armed == id);
-            // An action that resolved to nothing leaves the button just as
-            // dead as no action at all — `Ignored` is what an unimplemented
-            // function or an unresolvable openUrl becomes. Both answers to
-            // "can this button do anything?" have to be the same, or the
-            // note below is true of one path and a lie about the other.
-            let inert = !opens_a_modal && matches!(msg, None | Some(A2uiMsg::Ignored));
-            // A failing check is the whole point of putting one on a
-            // button: it must not carry out its action. Decided here, before
-            // the widget is built, because the kit bakes disabled styling in
-            // at build time.
-            let blocked = failure.is_some();
-            if blocked && opens_a_modal {
-                ctx.blocked_trigger.set(true);
-            }
-            // A blocked URL scheme already recorded *why* this button does
-            // nothing, and it is not "no action it can carry out" — the
-            // action was understood and deliberately refused. Two Broken
-            // notes for one cause, the second of them untrue, is worse than
-            // one.
-            if inert && !ctx.noted(id, NoteKind::BlockedUrlScheme) {
-                ctx.note(
-                    id,
-                    NoteKind::Unreachable,
-                    "button has no action it can carry out and opens nothing; rendered as a \
-                     disabled control",
-                );
-            }
-            match label {
-                Some(label) => {
-                    let mut b = button(label).variant(kit_variant);
-                    // A modal trigger has something to do even without an
-                    // action of its own, so it must not be *built* disabled
-                    // — see `Ctx::armed_triggers`.
-                    if inert || blocked {
-                        b = b.disabled(true);
-                    } else if let Some(m) = msg {
-                        b = b.on_click(m);
-                    }
-                    labeled_control(None, b.into(), failure, ctx.theme)
-                }
-                None => {
-                    let inner = render_by_id(ctx, child, scope, depth + 1);
-                    let mut b = icon_button(inner);
-                    // Same rule as the labeled branch — an inert button
-                    // must *look* inert, or the note above is a lie and the
-                    // user presses a live-looking control that does nothing.
-                    if inert || blocked {
-                        b = b.disabled(true);
-                    } else if let Some(m) = msg {
-                        b = b.on_click(m);
-                    }
-                    labeled_control(None, b.into(), failure, ctx.theme)
-                }
-            }
-        }
         Kind::TextField {
             label,
             value,
@@ -2014,6 +2186,15 @@ fn render_component(
                 format!("component {name:?} {why}; rendering a placeholder"),
             );
             placeholder(format!("[{name}]"), theme)
+        }
+        Kind::Row { .. }
+        | Kind::Column { .. }
+        | Kind::List { .. }
+        | Kind::Card { .. }
+        | Kind::Tabs { .. }
+        | Kind::Modal { .. }
+        | Kind::Button { .. } => {
+            unreachable!("container kinds are dispatched by render_component")
         }
     }
 }

--- a/fenestra-a2ui/src/render.rs
+++ b/fenestra-a2ui/src/render.rs
@@ -197,7 +197,8 @@ pub enum A2uiSignal {
     /// Two rules, not one. The scheme must be in [`OPENABLE_SCHEMES`]; and
     /// a `mailto:` must additionally carry only the header fields a
     /// generated link needs (`to`, `cc`, `bcc`, `subject`, `body`,
-    /// `in-reply-to`), with no CR or LF in their values — an allowed scheme
+    /// `in-reply-to`), with no CR or LF in the address or in the values of
+    /// the ones that become headers — an allowed scheme
     /// is not an allowed URL, since a mail client that honours an
     /// attachment field will stage a local file the user never chose.
     /// Field names and values are percent-decoded before either check.
@@ -252,6 +253,19 @@ pub const OPENABLE_SCHEMES: &[&str] = &["http", "https", "mailto"];
 /// URL unopenable rather than being passed through and hoped about.
 const MAILTO_SAFE_FIELDS: &[&str] = &["to", "cc", "bcc", "subject", "body", "in-reply-to"];
 
+/// The subset of [`MAILTO_SAFE_FIELDS`] whose value becomes a message
+/// *header*, and therefore may not contain a line break.
+///
+/// `body` is deliberately absent, and that is not an oversight: RFC 6068
+/// §6.1's own worked example is
+/// `mailto:infobot@example.com?body=send%20current-issue%0D%0Asend%20index`,
+/// where `%0D%0A` is how the spec says to write a newline in a message
+/// body. Banning CR/LF everywhere — which the first cut of this check did —
+/// refuses a conformant multi-line mail link and tells its author the
+/// scheme is unopenable. A body cannot inject a header; it *is* the payload,
+/// and everything after the header block belongs to it.
+const MAILTO_HEADER_FIELDS: &[&str] = &["to", "cc", "bcc", "subject", "in-reply-to"];
+
 /// Whether `url` is something a host may hand to a platform opener — the
 /// renderer's own decision, in full.
 ///
@@ -265,7 +279,9 @@ const MAILTO_SAFE_FIELDS: &[&str] = &["to", "cc", "bcc", "subject", "body", "in-
 ///
 /// The rules: the scheme must be one of [`OPENABLE_SCHEMES`]; and a
 /// `mailto:` may carry only the header fields a generated link needs, with
-/// no CR or LF in their values. Names and values are percent-decoded
+/// no CR or LF in the address or in the values of the ones that become
+/// headers (`body` may contain them; RFC 6068 §6.1 requires that). Names
+/// and values are percent-decoded
 /// first. A URL with no scheme at all is refused too — `open(1)` and
 /// `xdg-open` both treat a bare path as a local file, so a "relative" URL
 /// is a `file:` in disguise, and a surface meaning to link to the web can
@@ -307,15 +323,32 @@ fn is_openable(url: &str) -> bool {
     true
 }
 
-/// Whether every header field in a `mailto:` body is one a generated link
-/// may carry (see [`MAILTO_SAFE_FIELDS`]).
+/// Whether a `mailto:` carries only things a generated link may carry.
 ///
-/// A URL with no query carries no fields and is safe. An unparseable or
-/// unknown field fails closed: a name that percent-decodes to something
-/// containing its own `&` or `=` does not match any allowed field, so a
+/// Two halves, because a `mailto:` has two. The address part (RFC 6068's
+/// `to`, everything before `?`) is checked for line breaks, and the query
+/// part is checked field by field against [`MAILTO_SAFE_FIELDS`].
+///
+/// Checking only the query — which the first cut of this did, by discarding
+/// the address with `let Some((_, query))` — missed the simpler attack
+/// entirely: `mailto:victim@example.com%0D%0Aattach=/path` has no `?` at
+/// all, so the function returned `true` without inspecting anything. The
+/// address is `pct-encoded`-capable in the same way the fields are, so it
+/// smuggles a header just as well and needs the same rule.
+///
+/// An unparseable or unknown field fails closed: a name that percent-decodes
+/// to something containing its own `&` or `=` matches no allowed field, so a
 /// stream cannot smuggle a second field inside the first one's name.
 fn mailto_fields_are_safe(rest: &str) -> bool {
-    let Some((_, query)) = rest.split_once('?') else {
+    let (addr, query) = match rest.split_once('?') {
+        Some((addr, query)) => (addr, Some(query)),
+        None => (rest, None),
+    };
+    // The address is a header value like any other.
+    if has_line_break(addr) {
+        return false;
+    }
+    let Some(query) = query else {
         return true;
     };
     query
@@ -324,18 +357,29 @@ fn mailto_fields_are_safe(rest: &str) -> bool {
         .all(|pair| {
             let (raw_name, raw_value) = pair.split_once('=').unwrap_or((pair, ""));
             let name = percent_decode(raw_name);
-            let permitted = MAILTO_SAFE_FIELDS
+            let name = name.trim();
+            if !MAILTO_SAFE_FIELDS
                 .iter()
-                .any(|f| name.trim().eq_ignore_ascii_case(f));
-            // Naming a safe field is not enough: these values are written
-            // into message headers, and RFC 6068 §7 warns that a client
-            // doing so without sanitizing can be made to emit headers the
-            // URL never listed. A decoded CR or LF in `subject` is how
-            // `attach` gets added behind an allowlist that only ever
-            // inspected names — the encoded-value twin of the encoded-name
-            // hole this allowlist replaced.
-            permitted && !percent_decode(raw_value).contains(['\r', '\n'])
+                .any(|f| name.eq_ignore_ascii_case(f))
+            {
+                return false;
+            }
+            // Naming a safe field is not enough for the ones that become
+            // headers: RFC 6068 §7 warns that a client writing them out
+            // without sanitizing can be made to emit fields the URL never
+            // listed, and a decoded CR or LF in `subject` is how `attach`
+            // gets added behind an allowlist that only inspected names.
+            // `body` is exempt — see [`MAILTO_HEADER_FIELDS`].
+            !MAILTO_HEADER_FIELDS
+                .iter()
+                .any(|f| name.eq_ignore_ascii_case(f))
+                || !has_line_break(raw_value)
         })
+}
+
+/// Whether `raw` contains a CR or LF once percent-decoding is applied.
+fn has_line_break(raw: &str) -> bool {
+    percent_decode(raw).contains(['\r', '\n'])
 }
 
 /// Percent-decodes a `mailto:` header field name.
@@ -425,7 +469,7 @@ struct Ctx<'a> {
     blocked_trigger: std::cell::Cell<bool>,
     /// How many more children this render may build, from any source.
     ///
-    /// [`MAX_TEMPLATE_CHILDREN`] bounds one template expansion; this bounds
+    /// [`MAX_CHILDREN_PER_EXPANSION`] bounds one child list; this bounds
     /// the product of every nesting level, static lists included. An
     /// absolute template path is scope-invariant by design, so nesting
     /// templates over the same list multiplies without ever repeating a
@@ -699,8 +743,9 @@ impl Surface {
                         "",
                         NoteKind::BlockedUrlScheme,
                         format!(
-                            "openUrl {} is not a scheme this renderer will open; \
-                             the signal was not emitted",
+                            "openUrl {} is not a URL this renderer will open (the scheme, or \
+                             for mailto: the header fields it carries); the signal \
+                             was not emitted",
                             quoted(&url)
                         ),
                     ));
@@ -1483,6 +1528,26 @@ fn placeholder<Msg: 'static>(label: String, theme: &Theme) -> Element<Msg> {
 }
 
 fn render_by_id(ctx: &Ctx, id: &str, scope: Option<&str>, depth: usize) -> Element<A2uiMsg> {
+    // Charged first, before every early return below, because each of those
+    // returns builds a placeholder — and a placeholder is an `Element` and
+    // two `String`s, which is work an untrusted stream can ask for. Charging
+    // after them (the first cut of this) left the bound bypassable roughly
+    // a thousandfold: a `Column` naming one undefined id a thousand times
+    // costs one charge and builds a thousand `[missing: ..]` placeholders,
+    // and every charged component can host another such list. The same free
+    // multiplier sat behind the cycle and depth-cap returns. What the budget
+    // has to bound is *calls that build something*, which is all of them.
+    if !ctx.charge_child() {
+        ctx.note(
+            id,
+            NoteKind::Truncated,
+            format!(
+                "this render reached its {MAX_RENDERED_CHILDREN}-component budget; \
+                 {id:?} and anything below it were not built (nested containers multiply)"
+            ),
+        );
+        return placeholder(format!("[budget: {id}]"), ctx.theme);
+    }
     if ctx.path_stack.borrow().iter().any(|p| p == id) {
         ctx.note(
             id,
@@ -1507,20 +1572,6 @@ fn render_by_id(ctx: &Ctx, id: &str, scope: Option<&str>, depth: usize) -> Eleme
         );
         return placeholder(format!("[missing: {id}]"), ctx.theme);
     };
-    // Every materialized component is charged here, which is the only place
-    // all of them pass through. See [`Ctx::charge_child`] for why charging
-    // at the container instead left four ways around the bound.
-    if !ctx.charge_child() {
-        ctx.note(
-            id,
-            NoteKind::Truncated,
-            format!(
-                "this render reached its {MAX_RENDERED_CHILDREN}-component budget; \
-                 {id:?} and anything below it were not built (nested containers multiply)"
-            ),
-        );
-        return placeholder(format!("[budget: {id}]"), ctx.theme);
-    }
     ctx.path_stack.borrow_mut().push(id.to_owned());
     let el = render_component(ctx, component, scope, depth);
     ctx.path_stack.borrow_mut().pop();
@@ -2432,8 +2483,9 @@ fn action_msg(ctx: &Ctx, id: &str, action: &Action, scope: Option<&str>) -> A2ui
                     id,
                     NoteKind::BlockedUrlScheme,
                     format!(
-                        "openUrl {} is not a scheme this renderer will open; \
-                         the control does nothing",
+                        "openUrl {} is not a URL this renderer will open (the scheme, \
+                         or for mailto: the header fields it carries); the control \
+                         does nothing",
                         quoted(&url)
                     ),
                 );

--- a/fenestra-a2ui/tests/amplification.rs
+++ b/fenestra-a2ui/tests/amplification.rs
@@ -88,11 +88,12 @@ fn nested_templates_cannot_multiply_without_bound() {
 /// the old accounting.
 #[test]
 fn containers_that_bypass_children_of_are_charged_too() {
-    let items: Vec<String> = (0..200).map(|i| i.to_string()).collect();
-    // A Card chain deep enough to matter, well inside MAX_DEPTH.
-    let mut cards: Vec<String> = (0..10)
+    // 1000 template rows, each hanging a 14-deep Card chain — 15 001
+    // components, of which the old accounting charged only the 1000.
+    let items: Vec<String> = (0..1000).map(|i| i.to_string()).collect();
+    let mut cards: Vec<String> = (0..14)
         .map(|i| {
-            let next = if i == 9 {
+            let next = if i == 13 {
                 "leaf".to_owned()
             } else {
                 format!("c{}", i + 1)
@@ -121,17 +122,24 @@ fn containers_that_bypass_children_of_are_charged_too() {
         .expect("surface")
         .render(&Theme::light());
 
-    let built = count_elements(&rendered.element);
-    assert!(
-        built < 20_000,
-        "a Card chain under every template row built {built} elements; Card, \
-         Tabs, Modal and Button reach children without going through \
-         children_of, so charging the container is not charging the render"
-    );
+    // The note is the discriminator, not the element count. Under the old
+    // accounting the 1000 template rows fit the budget with room to spare,
+    // so nothing was ever reported as dropped — while the 14 000 Cards
+    // hanging off them were built for free. A `Truncated` note here means
+    // the Cards were counted.
     assert!(
         rendered.notes.iter().any(|n| n.kind == NoteKind::Truncated),
-        "work dropped to stay inside the budget must be reported, got: {:?}",
+        "15 001 components were built without one being reported as dropped; \
+         Card, Tabs, Modal and Button reach children without going through \
+         children_of, so charging the container is not charging the render. \
+         Notes: {:?}",
         rendered.notes
+    );
+    let built = count_elements(&rendered.element);
+    assert!(
+        built < 30_000,
+        "the budget bounds components, and each refusal still costs a small \
+         placeholder; {built} elements is past what either accounts for"
     );
 }
 
@@ -152,10 +160,19 @@ fn containers_that_bypass_children_of_are_charged_too() {
 /// note, no error, and nothing for a caller to catch.
 ///
 /// A strictly linear chain, one child per level: no template, no fan-out,
-/// nothing amplified. The only variable is depth. It runs on an explicitly
-/// 2 MiB thread because that is what `std::thread` and tokio's blocking
-/// pool give by default — the test harness's own main thread is 8 MiB and
-/// would have hidden the bug for another four levels.
+/// nothing amplified. The only variable is depth.
+///
+/// It runs on an explicitly sized thread, at **half** the 2 MiB that
+/// `std::thread` and tokio's blocking pool give by default, so that the
+/// pass carries a 2x margin rather than merely being true today. Two
+/// reasons for the margin. The harness's own main thread is 8 MiB and
+/// would have hidden the original bug for another four levels, so a test
+/// that inherits its stack tests nothing; and a stack overflow `abort()`s
+/// rather than unwinding, which kills the whole test binary and reports as
+/// every test in the file failing on a signal, pointing at nothing — the
+/// `.expect` message below never gets to print. Failing at half the real
+/// stack means a frame that grows again shows up here while production
+/// still has room, instead of both giving out at once.
 #[test]
 fn renders_at_the_full_depth_cap() {
     // `MAX_DEPTH` is private; this mirrors it deliberately, so that raising
@@ -188,8 +205,12 @@ fn renders_at_the_full_depth_cap() {
         components.join(",")
     );
 
+    let stack: usize = std::env::var("FENESTRA_PROBE_STACK")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(2 * 1024 * 1024);
     let built = std::thread::Builder::new()
-        .stack_size(2 * 1024 * 1024)
+        .stack_size(stack)
         .spawn(move || {
             let client = apply(&stream);
             let rendered = client
@@ -294,21 +315,25 @@ fn static_children_cannot_multiply_without_bound() {
 /// re-open the product this pair of tests exists to close.
 #[test]
 fn the_child_budget_is_shared_between_static_and_template_children() {
-    // Each arm stays *under* the budget on its own — 40 static children and
-    // 6000 template children — so only a shared counter can truncate this.
-    // (Written the other way first, with 12 000 static children, it passed
-    // identically against two separate per-arm budgets and proved nothing:
-    // the static arm blew its own ceiling unaided.)
-    let items: Vec<String> = (0..60).map(|i| i.to_string()).collect();
-    let forty = (0..40).map(|_| "\"a\"").collect::<Vec<_>>().join(",");
+    // 100 static -> 50 template each -> 1 static each: 5100 static children
+    // and 5000 template children, so *neither arm reaches the 10 000 budget
+    // on its own* and only a shared counter can truncate the 10 101 total.
+    //
+    // Both earlier shapes of this test were wrong in opposite directions:
+    // the first had 12 010 static children, which blows the cap unaided and
+    // so passed against two separate per-arm budgets; the second had 2441
+    // components total and never reached any cap at all.
+    let items: Vec<String> = (0..50).map(|i| i.to_string()).collect();
+    let hundred = (0..100).map(|_| "\"a\"").collect::<Vec<_>>().join(",");
     let stream = format!(
         r#"[
           {{"version":"v0.9","createSurface":{{"surfaceId":"s","catalogId":"basic"}}}},
           {{"version":"v0.9","updateDataModel":{{"surfaceId":"s","path":"/items",
             "value":[{}]}}}},
           {{"version":"v0.9","updateComponents":{{"surfaceId":"s","components":[
-            {{"id":"root","component":"Column","children":[{forty}]}},
-            {{"id":"a","component":"Column","children":{{"componentId":"leaf","path":"/items"}}}},
+            {{"id":"root","component":"Column","children":[{hundred}]}},
+            {{"id":"a","component":"Column","children":{{"componentId":"b","path":"/items"}}}},
+            {{"id":"b","component":"Column","children":["leaf"]}},
             {{"id":"leaf","component":"Text","text":"x"}}
           ]}}}}
         ]"#,

--- a/fenestra-a2ui/tests/amplification.rs
+++ b/fenestra-a2ui/tests/amplification.rs
@@ -20,7 +20,7 @@ fn count_elements<Msg>(el: &Element<Msg>) -> usize {
 
 /// Finding 1: nested templates multiply, and only each factor was capped.
 ///
-/// `MAX_TEMPLATE_CHILDREN` bounds one expansion at 1000. Nothing bounded
+/// `MAX_CHILDREN_PER_EXPANSION` bounds one expansion at 1000. Nothing bounded
 /// the *product*: an absolute template path is scope-invariant by design
 /// (that is the fix for `//`-corrupted pointers), so every level of nesting
 /// can expand the same array again, and cycle detection does not fire
@@ -162,17 +162,27 @@ fn containers_that_bypass_children_of_are_charged_too() {
 /// A strictly linear chain, one child per level: no template, no fan-out,
 /// nothing amplified. The only variable is depth.
 ///
-/// It runs on an explicitly sized thread, at **half** the 2 MiB that
-/// `std::thread` and tokio's blocking pool give by default, so that the
-/// pass carries a 2x margin rather than merely being true today. Two
-/// reasons for the margin. The harness's own main thread is 8 MiB and
-/// would have hidden the original bug for another four levels, so a test
-/// that inherits its stack tests nothing; and a stack overflow `abort()`s
-/// rather than unwinding, which kills the whole test binary and reports as
-/// every test in the file failing on a signal, pointing at nothing — the
-/// `.expect` message below never gets to print. Failing at half the real
-/// stack means a frame that grows again shows up here while production
-/// still has room, instead of both giving out at once.
+/// It runs on an explicitly sized thread — 2 MiB, matching what
+/// `std::thread` and tokio's blocking pool give by default — because the
+/// harness's own main thread is 8 MiB and would have hidden the original
+/// bug for another four levels. A test that inherits the harness stack
+/// tests nothing.
+///
+/// **The margin is thin, and this test does not widen it.** Measured with
+/// `FENESTRA_PROBE_STACK` (which overrides the size below), the renderer
+/// needs between 1.5 and 2 MiB at `MAX_DEPTH`: it renders at 2048 KiB and
+/// overflows at 1536. Running at half would therefore abort rather than
+/// prove headroom — that was tried. So this pins the real configuration,
+/// and the honest reading of a pass is "the shipped default still works",
+/// not "there is room to spare". Raising `MAX_DEPTH`, or growing a
+/// recursive arm, needs a fresh measurement; ARCHITECTURE.md records where
+/// the remaining cost lives.
+///
+/// One caveat on the failure mode: a stack overflow `abort()`s rather than
+/// unwinding, so a regression kills the whole test binary and reports as
+/// every test in this file failing on a signal, pointing at nothing — the
+/// `.expect` message below never gets to print. If that is what CI shows,
+/// this is the test to suspect first.
 #[test]
 fn renders_at_the_full_depth_cap() {
     // `MAX_DEPTH` is private; this mirrors it deliberately, so that raising
@@ -232,6 +242,107 @@ fn renders_at_the_full_depth_cap() {
         .expect("rendering a surface at the documented depth cap must not abort the process");
 
     assert!(built > CAP, "expected a real chain, built {built} elements");
+}
+
+/// The same depth cap, through the *expensive* recursive arms.
+///
+/// `renders_at_the_full_depth_cap` uses a `Column` chain, which is the
+/// cheapest thing on the recursive path — and the per-level cost is what
+/// this whole area is about, so the cheapest arm is the least informative
+/// one to pin. `Modal` recurses twice per level (trigger and content) with
+/// a `modal(..).child(..).on_close(..)` builder chain and a `col().children`
+/// around it; `Card` and `Tabs` each carry their own; a `Button` with a
+/// non-Text child recurses after building its checks, label, variant and
+/// message. All are constructible from ordinary JSON and all sit inside
+/// `MAX_DEPTH`, so a chain of them is a surface a stream can ask for and
+/// nothing was watching it.
+///
+/// Modals are alternated with Cards so each level pays a Modal's two
+/// recursions plus a Card's builder chain.
+#[test]
+fn the_expensive_recursive_arms_also_render_at_the_full_depth_cap() {
+    const CAP: usize = 16;
+
+    let mut components: Vec<String> = Vec::new();
+    for i in 0..CAP {
+        let next = if i + 1 == CAP {
+            "leaf".to_owned()
+        } else {
+            format!("lvl{}", i + 1)
+        };
+        let id = if i == 0 {
+            "root".to_owned()
+        } else {
+            format!("lvl{i}")
+        };
+        if i % 2 == 0 {
+            // Chained through the *trigger*, which a Modal always renders;
+            // its `content` recurses only while the dialog is open, so a
+            // chain built through `content` stops at the first level and
+            // reports two elements — which is what the first cut of this
+            // test did, and why it is worth saying here.
+            components.push(format!(
+                r#"{{"id":"{id}","component":"Modal","trigger":"{next}","content":"body{i}"}}"#
+            ));
+            components.push(format!(
+                r#"{{"id":"body{i}","component":"Text","text":"dialog"}}"#
+            ));
+        } else {
+            components.push(format!(
+                r#"{{"id":"{id}","component":"Card","child":"{next}"}}"#
+            ));
+        }
+    }
+    components.push(r#"{"id":"leaf","component":"Text","text":"deep"}"#.to_owned());
+    let stream = format!(
+        r#"[
+          {{"version":"v0.9","createSurface":{{"surfaceId":"s","catalogId":"basic"}}}},
+          {{"version":"v0.9","updateComponents":{{"surfaceId":"s","components":[{}]}}}}
+        ]"#,
+        components.join(",")
+    );
+
+    let stack: usize = std::env::var("FENESTRA_PROBE_STACK")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(2 * 1024 * 1024);
+    let built = std::thread::Builder::new()
+        .stack_size(stack)
+        .spawn(move || {
+            let client = apply(&stream);
+            let rendered = client
+                .surface("s")
+                .expect("surface")
+                .render(&Theme::light());
+            assert!(
+                !rendered.notes.iter().any(|n| n.kind == NoteKind::DepthCap),
+                "the cap refused a chain it permits: {:?}",
+                rendered.notes
+            );
+            (count_elements(&rendered.element), rendered.notes)
+        })
+        .expect("spawn")
+        .join()
+        .expect(
+            "a Modal/Card chain at the documented depth cap must not abort the process — \
+             the Column chain passing does not cover the arms with the largest frames",
+        );
+    let (built, notes) = built;
+
+    // Element count is the wrong proxy for depth here, and finding that out
+    // is worth recording: a *closed* Modal returns its trigger and adds no
+    // element of its own, so sixteen levels of Modal/Card come back as ten
+    // elements. What proves the recursion ran the whole way is that the
+    // deepest Modal in the chain rendered — it can only have produced a note
+    // by having been reached — together with the absence of a DepthCap note
+    // above.
+    let deepest_modal = format!("lvl{}", CAP - 2);
+    assert!(
+        notes.iter().any(|n| n.component_id == deepest_modal),
+        "the chain stopped short of {deepest_modal}, so this never exercised the \
+         depth it claims; built {built} elements, notes: {notes:?}"
+    );
+    assert!(built > 0, "nothing rendered at all");
 }
 
 /// The static sibling of the finding above, and the one it missed.
@@ -350,7 +461,7 @@ fn the_child_budget_is_shared_between_static_and_template_children() {
     assert!(
         built < 20_000,
         "alternating static and template levels built {built} elements; the two \
-         arms must draw down one shared budget (40 static + 6000 template is \
+         arms must draw down one shared budget (5100 static + 5000 template is \
          under either cap taken alone)"
     );
     assert!(
@@ -538,4 +649,54 @@ fn the_basic_catalog_is_not_foreign_by_either_name() {
             rendered.notes
         );
     }
+}
+
+/// A refusal is work too, so it has to be charged.
+///
+/// The budget's first cut charged *after* the cycle, depth-cap and
+/// missing-component early returns — each of which builds a placeholder.
+/// That left the bound bypassable roughly a thousandfold: a `Column` naming
+/// one undefined id a thousand times costs a single charge and builds a
+/// thousand `[missing: ..]` placeholders, and every charged component can
+/// host another such list. 1000 x 1000 from ~20 KB of JSON, with the
+/// budget reporting 1001 of 10 000 spent.
+#[test]
+fn refusals_are_charged_to_the_budget_too() {
+    let thousand = |id: &str| {
+        (0..1000)
+            .map(|_| format!("\"{id}\""))
+            .collect::<Vec<_>>()
+            .join(",")
+    };
+    let stream = format!(
+        r#"[
+          {{"version":"v0.9","createSurface":{{"surfaceId":"s","catalogId":"basic"}}}},
+          {{"version":"v0.9","updateComponents":{{"surfaceId":"s","components":[
+            {{"id":"root","component":"Column","children":[{}]}},
+            {{"id":"a","component":"Column","children":[{}]}}
+          ]}}}}
+        ]"#,
+        thousand("a"),
+        thousand("zz"),
+    );
+
+    let client = apply(&stream);
+    let started = Instant::now();
+    let rendered = client
+        .surface("s")
+        .expect("surface")
+        .render(&Theme::light());
+    let elapsed = started.elapsed();
+
+    let built = count_elements(&rendered.element);
+    assert!(
+        built < 40_000,
+        "{built} elements from a stream naming one undefined id; a placeholder \
+         is an Element and two Strings, so a refusal has to be charged like \
+         anything else this builds"
+    );
+    assert!(
+        elapsed.as_secs() < 5,
+        "rendering took {elapsed:?}; refusals must not be a free multiplier"
+    );
 }

--- a/fenestra-a2ui/tests/amplification.rs
+++ b/fenestra-a2ui/tests/amplification.rs
@@ -72,6 +72,204 @@ fn nested_templates_cannot_multiply_without_bound() {
     );
 }
 
+/// A surface may nest as deeply as `MAX_DEPTH` says it may, on the stack
+/// the renderer actually runs on.
+///
+/// This is the regression test for a crash, not a slowdown. `render_by_id`
+/// -> `render_component` -> `children_of` -> `render_by_id` is a recursive
+/// cycle, and `render_component` used to be a single `match` over all
+/// nineteen component kinds. An unoptimized build gives such a frame room
+/// for every arm's locals at once, so each level of nesting cost what the
+/// *largest* arm needed — and the largest arms (`ChoicePicker`, `Slider`,
+/// `DateTimeInput`) are leaves that cannot even appear on the recursive
+/// path. On a 2 MiB stack the result overflowed at **seven** levels: not
+/// an attack, an ordinary surface, since a Card inside a List inside a Tab
+/// is already half the budget. A stack overflow aborts the process instead
+/// of unwinding, so this was `SIGABRT` for the whole MCP server, with no
+/// note, no error, and nothing for a caller to catch.
+///
+/// A strictly linear chain, one child per level: no template, no fan-out,
+/// nothing amplified. The only variable is depth. It runs on an explicitly
+/// 2 MiB thread because that is what `std::thread` and tokio's blocking
+/// pool give by default — the test harness's own main thread is 8 MiB and
+/// would have hidden the bug for another four levels.
+#[test]
+fn renders_at_the_full_depth_cap() {
+    // `MAX_DEPTH` is private; this mirrors it deliberately, so that raising
+    // the cap without re-measuring the stack shows up as a failure here.
+    const CAP: usize = 16;
+
+    // `CAP` containers, so the deepest node — the leaf — sits at exactly
+    // `MAX_DEPTH`. One more would be the cap legitimately refusing.
+    let mut components: Vec<String> = (0..CAP)
+        .map(|i| {
+            let next = if i + 1 == CAP {
+                "leaf".to_owned()
+            } else {
+                format!("lvl{}", i + 1)
+            };
+            let id = if i == 0 {
+                "root".to_owned()
+            } else {
+                format!("lvl{i}")
+            };
+            format!(r#"{{"id":"{id}","component":"Column","children":["{next}"]}}"#)
+        })
+        .collect();
+    components.push(r#"{"id":"leaf","component":"Text","text":"deep"}"#.to_owned());
+    let stream = format!(
+        r#"[
+          {{"version":"v0.9","createSurface":{{"surfaceId":"s","catalogId":"basic"}}}},
+          {{"version":"v0.9","updateComponents":{{"surfaceId":"s","components":[{}]}}}}
+        ]"#,
+        components.join(",")
+    );
+
+    let built = std::thread::Builder::new()
+        .stack_size(2 * 1024 * 1024)
+        .spawn(move || {
+            let client = apply(&stream);
+            let rendered = client
+                .surface("s")
+                .expect("surface")
+                .render(&Theme::light());
+            // The chain must actually render, not bottom out in a
+            // `[deep: ..]` placeholder — that would pass the crash test
+            // while proving nothing about the cap.
+            assert!(
+                !rendered.notes.iter().any(|n| n.kind == NoteKind::DepthCap),
+                "the cap refused a chain it permits: {:?}",
+                rendered.notes
+            );
+            count_elements(&rendered.element)
+        })
+        .expect("spawn")
+        .join()
+        .expect("rendering a surface at the documented depth cap must not abort the process");
+
+    assert!(built > CAP, "expected a real chain, built {built} elements");
+}
+
+/// The static sibling of the finding above, and the one it missed.
+///
+/// `nested_templates_cannot_multiply_without_bound` fixed the *template*
+/// arm of `children_of` by charging every materialized child to a
+/// render-wide budget. The `Static` arm was left drawing from nothing at
+/// all — and a static child list is the cheaper amplifier of the two,
+/// because it needs no data model to expand against. Cycle detection does
+/// not fire (each level is a distinct component id), and the framework
+/// guards element-tree *depth* only, never breadth, so nothing downstream
+/// catches it either.
+///
+/// Three `Column`s naming the next one fifty times is 127 551 components
+/// from about a kilobyte of JSON, and the shape scales as fan-out to the
+/// power of the nesting depth. Every consumer reaches this through
+/// `Surface::render` on agent-supplied input — the MCP `render_a2ui` tool
+/// most directly.
+///
+/// Deliberately wide and shallow: breadth is what this test is about, and
+/// nesting it deeper would trip the *separate* stack-depth limit instead
+/// and prove nothing about the budget.
+#[test]
+fn static_children_cannot_multiply_without_bound() {
+    let kids = |next: &str| {
+        (0..50)
+            .map(|_| format!("\"{next}\""))
+            .collect::<Vec<_>>()
+            .join(",")
+    };
+    let stream = format!(
+        r#"[
+          {{"version":"v0.9","createSurface":{{"surfaceId":"s","catalogId":"basic"}}}},
+          {{"version":"v0.9","updateComponents":{{"surfaceId":"s","components":[
+            {{"id":"root","component":"Column","children":[{}]}},
+            {{"id":"lvl1","component":"Column","children":[{}]}},
+            {{"id":"lvl2","component":"Column","children":[{}]}},
+            {{"id":"leaf","component":"Text","text":"x"}}
+          ]}}}}
+        ]"#,
+        kids("lvl1"),
+        kids("lvl2"),
+        kids("leaf"),
+    );
+    assert!(
+        stream.len() < 2048,
+        "the point is that the input is tiny; this one is {} bytes",
+        stream.len()
+    );
+
+    let client = apply(&stream);
+    let started = Instant::now();
+    let rendered = client
+        .surface("s")
+        .expect("surface")
+        .render(&Theme::light());
+    let elapsed = started.elapsed();
+
+    let built = count_elements(&rendered.element);
+    assert!(
+        built < 100_000,
+        "static children built {built} elements from a {}-byte stream; every \
+         materialized child must be charged to the render-wide budget, not just \
+         the ones a template generated",
+        stream.len()
+    );
+    assert!(
+        rendered.notes.iter().any(|n| n.kind == NoteKind::Truncated),
+        "work dropped to stay inside the budget must be reported, got: {:?}",
+        rendered.notes
+    );
+    assert!(
+        elapsed.as_secs() < 5,
+        "rendering took {elapsed:?}; a hostile stream must not be able to stall a render"
+    );
+}
+
+/// The budget is shared, so the two arms cannot be played against each
+/// other: a template expansion that spends it must leave static children
+/// bounded too, and the reverse. Charging them to separate counters would
+/// re-open the product this pair of tests exists to close.
+#[test]
+fn the_child_budget_is_shared_between_static_and_template_children() {
+    let items: Vec<String> = (0..60).map(|i| i.to_string()).collect();
+    let ten = (0..10).map(|_| "\"a\"").collect::<Vec<_>>().join(",");
+    let twenty = (0..20).map(|_| "\"leaf\"").collect::<Vec<_>>().join(",");
+    // Static, then template, then static — 10 x 60 x 20 = 12 000 children
+    // across three levels, so neither arm reaches the budget alone.
+    let stream = format!(
+        r#"[
+          {{"version":"v0.9","createSurface":{{"surfaceId":"s","catalogId":"basic"}}}},
+          {{"version":"v0.9","updateDataModel":{{"surfaceId":"s","path":"/items",
+            "value":[{}]}}}},
+          {{"version":"v0.9","updateComponents":{{"surfaceId":"s","components":[
+            {{"id":"root","component":"Column","children":[{ten}]}},
+            {{"id":"a","component":"Column","children":{{"componentId":"b","path":"/items"}}}},
+            {{"id":"b","component":"Column","children":[{twenty}]}},
+            {{"id":"leaf","component":"Text","text":"x"}}
+          ]}}}}
+        ]"#,
+        items.join(","),
+    );
+
+    let client = apply(&stream);
+    let rendered = client
+        .surface("s")
+        .expect("surface")
+        .render(&Theme::light());
+
+    let built = count_elements(&rendered.element);
+    assert!(
+        built < 100_000,
+        "alternating static and template levels built {built} elements; the two \
+         arms must draw down one shared budget"
+    );
+    assert!(
+        rendered.notes.iter().any(|n| n.kind == NoteKind::Truncated),
+        "work dropped to stay inside the budget must be reported, got: {:?}",
+        rendered.notes
+    );
+}
+
 /// Finding 2: `Ctx::modal_triggers` was built from every component the
 /// surface has ever defined, not from the ones actually rendered.
 ///

--- a/fenestra-a2ui/tests/amplification.rs
+++ b/fenestra-a2ui/tests/amplification.rs
@@ -72,6 +72,69 @@ fn nested_templates_cannot_multiply_without_bound() {
     );
 }
 
+/// The budget has to be charged where components are *built*, not where a
+/// container happens to ask for a list of them.
+///
+/// The first cut metered `children_of`, which is only how `Row`, `Column`
+/// and `List` reach their children. `Card`, `Tabs`, `Modal` and `Button`
+/// call `render_by_id` directly, and every one of those was an uncharged
+/// multiplier stacked on a charged one: a `Card` chain multiplies the
+/// ceiling by its depth, and a `Modal` — which renders its trigger *and*
+/// its content — by two per level. A ceiling with four ways around it is
+/// not a ceiling.
+///
+/// Here a template drains the budget and every one of the components it
+/// paid for then hangs a deep `Card` chain underneath, all of it free under
+/// the old accounting.
+#[test]
+fn containers_that_bypass_children_of_are_charged_too() {
+    let items: Vec<String> = (0..200).map(|i| i.to_string()).collect();
+    // A Card chain deep enough to matter, well inside MAX_DEPTH.
+    let mut cards: Vec<String> = (0..10)
+        .map(|i| {
+            let next = if i == 9 {
+                "leaf".to_owned()
+            } else {
+                format!("c{}", i + 1)
+            };
+            format!(r#"{{"id":"c{i}","component":"Card","child":"{next}"}}"#)
+        })
+        .collect();
+    cards.push(r#"{"id":"leaf","component":"Text","text":"x"}"#.to_owned());
+    let stream = format!(
+        r#"[
+          {{"version":"v0.9","createSurface":{{"surfaceId":"s","catalogId":"basic"}}}},
+          {{"version":"v0.9","updateDataModel":{{"surfaceId":"s","path":"/items",
+            "value":[{}]}}}},
+          {{"version":"v0.9","updateComponents":{{"surfaceId":"s","components":[
+            {{"id":"root","component":"Column","children":{{"componentId":"c0","path":"/items"}}}},
+            {}
+          ]}}}}
+        ]"#,
+        items.join(","),
+        cards.join(","),
+    );
+
+    let client = apply(&stream);
+    let rendered = client
+        .surface("s")
+        .expect("surface")
+        .render(&Theme::light());
+
+    let built = count_elements(&rendered.element);
+    assert!(
+        built < 20_000,
+        "a Card chain under every template row built {built} elements; Card, \
+         Tabs, Modal and Button reach children without going through \
+         children_of, so charging the container is not charging the render"
+    );
+    assert!(
+        rendered.notes.iter().any(|n| n.kind == NoteKind::Truncated),
+        "work dropped to stay inside the budget must be reported, got: {:?}",
+        rendered.notes
+    );
+}
+
 /// A surface may nest as deeply as `MAX_DEPTH` says it may, on the stack
 /// the renderer actually runs on.
 ///
@@ -231,20 +294,21 @@ fn static_children_cannot_multiply_without_bound() {
 /// re-open the product this pair of tests exists to close.
 #[test]
 fn the_child_budget_is_shared_between_static_and_template_children() {
+    // Each arm stays *under* the budget on its own — 40 static children and
+    // 6000 template children — so only a shared counter can truncate this.
+    // (Written the other way first, with 12 000 static children, it passed
+    // identically against two separate per-arm budgets and proved nothing:
+    // the static arm blew its own ceiling unaided.)
     let items: Vec<String> = (0..60).map(|i| i.to_string()).collect();
-    let ten = (0..10).map(|_| "\"a\"").collect::<Vec<_>>().join(",");
-    let twenty = (0..20).map(|_| "\"leaf\"").collect::<Vec<_>>().join(",");
-    // Static, then template, then static — 10 x 60 x 20 = 12 000 children
-    // across three levels, so neither arm reaches the budget alone.
+    let forty = (0..40).map(|_| "\"a\"").collect::<Vec<_>>().join(",");
     let stream = format!(
         r#"[
           {{"version":"v0.9","createSurface":{{"surfaceId":"s","catalogId":"basic"}}}},
           {{"version":"v0.9","updateDataModel":{{"surfaceId":"s","path":"/items",
             "value":[{}]}}}},
           {{"version":"v0.9","updateComponents":{{"surfaceId":"s","components":[
-            {{"id":"root","component":"Column","children":[{ten}]}},
-            {{"id":"a","component":"Column","children":{{"componentId":"b","path":"/items"}}}},
-            {{"id":"b","component":"Column","children":[{twenty}]}},
+            {{"id":"root","component":"Column","children":[{forty}]}},
+            {{"id":"a","component":"Column","children":{{"componentId":"leaf","path":"/items"}}}},
             {{"id":"leaf","component":"Text","text":"x"}}
           ]}}}}
         ]"#,
@@ -259,9 +323,10 @@ fn the_child_budget_is_shared_between_static_and_template_children() {
 
     let built = count_elements(&rendered.element);
     assert!(
-        built < 100_000,
+        built < 20_000,
         "alternating static and template levels built {built} elements; the two \
-         arms must draw down one shared budget"
+         arms must draw down one shared budget (40 static + 6000 template is \
+         under either cap taken alone)"
     );
     assert!(
         rendered.notes.iter().any(|n| n.kind == NoteKind::Truncated),

--- a/fenestra-a2ui/tests/robustness.rs
+++ b/fenestra-a2ui/tests/robustness.rs
@@ -695,7 +695,11 @@ fn open_url_refuses_mailto_fields_that_are_not_plainly_safe() {
         // or LF inside a permitted field smuggles one in behind it — the
         // encoded-value twin of the encoded-name hole above.
         "mailto:victim@example.com?subject=Hi%0D%0Aattach=/Users/u/.ssh/id_rsa",
-        "mailto:victim@example.com?body=hello%0Abcc=attacker@example.com",
+        "mailto:victim@example.com?cc=a@b%0D%0Abcc=attacker@example.com",
+        "mailto:victim@example.com?in-reply-to=%3Cx@y%3E%0D%0Aattach=/etc/passwd",
+        // No `?` at all: the address half is percent-encodable too, and
+        // checking only the query missed this entirely.
+        "mailto:victim@example.com%0D%0Aattach=/Users/u/.ssh/id_rsa",
     ] {
         let stream = format!(
             r#"[
@@ -737,6 +741,13 @@ fn open_url_still_composes_ordinary_mail() {
         "mailto:someone@example.com?in-reply-to=%3Cabc@example.com%3E",
         // Empty query, and a bare address with a trailing '?'.
         "mailto:someone@example.com?",
+        // Verbatim from RFC 6068 §6.1: `%0D%0A` is how the spec says to
+        // write a line break in a *body*, so refusing it — which an
+        // earlier cut of the CR/LF rule did, by banning line breaks in
+        // every field — rejects a conformant multi-line mail link and
+        // blames the scheme. A body cannot inject a header; it is the
+        // payload, and everything after the header block belongs to it.
+        "mailto:infobot@example.com?body=send%20current-issue%0D%0Asend%20index",
     ] {
         let stream = format!(
             r#"[
@@ -842,15 +853,34 @@ fn the_public_url_check_matches_what_the_renderer_does() {
             !fenestra_a2ui::is_openable_url(url),
             "{url} must be refused"
         );
-        // And the trap the export exists to close: a scheme test alone
-        // accepts the mailto cases above, which is why a host must not
-        // re-derive this from OPENABLE_SCHEMES.
-        let scheme_only = fenestra_a2ui::OPENABLE_SCHEMES
+    }
+
+    // And the trap the export exists to close, stated as a property rather
+    // than a tautology: there is at least one URL a scheme-membership test
+    // accepts and `is_openable_url` refuses. Written the other way first —
+    // `!scheme_only || url.starts_with("mailto:")` over the loop above — it
+    // could not fail for any fixture and would have kept passing had
+    // `is_openable_url` been reduced to bare scheme membership.
+    let scheme_only = |url: &str| {
+        fenestra_a2ui::OPENABLE_SCHEMES
             .iter()
-            .any(|s| url.starts_with(&format!("{s}:")));
+            .any(|s| url.starts_with(&format!("{s}:")))
+    };
+    let divergent = [
+        "mailto:a@example.com?attach=/etc/passwd",
+        "mailto:a@example.com?%61ttach=/etc/passwd",
+        "mailto:a@example.com?subject=Hi%0D%0Aattach=/etc/passwd",
+        "mailto:victim@example.com%0D%0Aattach=/etc/passwd",
+    ];
+    for url in divergent {
         assert!(
-            !scheme_only || url.starts_with("mailto:"),
-            "{url} should not have passed a scheme-only test"
+            scheme_only(url),
+            "{url} must pass a scheme test, or it proves nothing about the gap"
+        );
+        assert!(
+            !fenestra_a2ui::is_openable_url(url),
+            "{url} passes a scheme test and must still be refused — this is the \
+             whole reason a host cannot re-derive the rule from OPENABLE_SCHEMES"
         );
     }
 }

--- a/fenestra-a2ui/tests/robustness.rs
+++ b/fenestra-a2ui/tests/robustness.rs
@@ -665,6 +665,146 @@ fn open_url_refuses_a_scheme_the_host_should_not_launch() {
     }
 }
 
+/// A `mailto:` header field is percent-encoded on the wire, and the
+/// blocklist compared the *raw* name.
+///
+/// RFC 6068 spells `hfname` as `*qchar`, and `qchar` includes
+/// `pct-encoded`; a conforming client percent-decodes the name before
+/// acting on it. So `%61ttach` is `attach` by the time it reaches the mail
+/// client, and it sailed past a check comparing it to the literal string
+/// `"attach"`. The same hole swallowed every vendor spelling nobody had
+/// thought to enumerate.
+///
+/// The fix is the one `OPENABLE_SCHEMES` already makes for schemes: the set
+/// of header fields a mail client will act on is open-ended, so name the
+/// few that are safe rather than the ones that are known to be dangerous.
+#[test]
+fn open_url_refuses_mailto_fields_that_are_not_plainly_safe() {
+    for url in [
+        // Percent-encoded, and therefore invisible to a literal comparison.
+        "mailto:attacker@example.com?%61ttach=/Users/u/.ssh/id_rsa",
+        "mailto:attacker@example.com?%41TTACHMENT=/etc/passwd",
+        "mailto:attacker@example.com?subject=hi&%61ttachment=/etc/passwd",
+        // A vendor spelling the old blocklist never enumerated. There is no
+        // finite list of these, which is the whole argument for an allowlist.
+        "mailto:attacker@example.com?x-mozilla-attach=/etc/passwd",
+        "mailto:attacker@example.com?attachurl=file:///etc/passwd",
+    ] {
+        let stream = format!(
+            r#"[
+            {{"version":"v0.9","createSurface":{{"surfaceId":"s","catalogId":"basic"}}}},
+            {{"version":"v0.9","updateComponents":{{"surfaceId":"s","components":[
+                {{"id":"root","component":"Button","child":"lbl",
+                 "action":{{"functionCall":{{"call":"openUrl","args":{{"url":"{url}"}}}}}}}},
+                {{"id":"lbl","component":"Text","text":"Mail"}}
+            ]}}}}
+        ]"#
+        );
+        let rendered = apply(&stream)
+            .surface("s")
+            .expect("surface")
+            .render(&Theme::light());
+        assert!(
+            rendered
+                .notes
+                .iter()
+                .any(|n| n.kind == NoteKind::BlockedUrlScheme),
+            "{url} must be refused, got: {:?}",
+            rendered.notes
+        );
+        assert!(
+            find_click(&rendered.element).is_none(),
+            "{url} left a live control that could reach the opener"
+        );
+    }
+}
+
+/// And the header fields a generated link legitimately uses keep working —
+/// an allowlist that blocked ordinary mail links would just get removed.
+#[test]
+fn open_url_still_composes_ordinary_mail() {
+    for url in [
+        "mailto:someone@example.com?subject=Hello%20there",
+        "mailto:someone@example.com?subject=Report&body=See%20attached%20link",
+        "mailto:a@example.com?cc=b@example.com&bcc=c@example.com",
+        "mailto:someone@example.com?in-reply-to=%3Cabc@example.com%3E",
+        // Empty query, and a bare address with a trailing '?'.
+        "mailto:someone@example.com?",
+    ] {
+        let stream = format!(
+            r#"[
+            {{"version":"v0.9","createSurface":{{"surfaceId":"s","catalogId":"basic"}}}},
+            {{"version":"v0.9","updateComponents":{{"surfaceId":"s","components":[
+                {{"id":"root","component":"Button","child":"lbl",
+                 "action":{{"functionCall":{{"call":"openUrl","args":{{"url":"{url}"}}}}}}}},
+                {{"id":"lbl","component":"Text","text":"Mail"}}
+            ]}}}}
+        ]"#
+        );
+        let mut client = apply(&stream);
+        let surface = client.surface_mut("s").expect("surface");
+        let rendered = surface.render(&Theme::light());
+        assert!(
+            !rendered
+                .notes
+                .iter()
+                .any(|n| n.kind == NoteKind::BlockedUrlScheme),
+            "{url} is an ordinary mail link, got: {:?}",
+            rendered.notes
+        );
+        let msg = find_click(&rendered.element).expect("the link is clickable");
+        assert!(
+            surface
+                .handle(msg)
+                .iter()
+                .any(|s| matches!(s, A2uiSignal::OpenUrl(u) if u == url)),
+            "{url} must reach the host"
+        );
+    }
+}
+
+/// `A2uiSignal::OpenUrl` tells its reader the URL is safe to hand to a
+/// platform opener. That has to be true of every one the host can receive,
+/// not only of the ones this renderer happened to construct.
+///
+/// `A2uiMsg` is public, so a host can hold one it built itself, replayed
+/// from a log, or round-tripped through its own message type, and hand it
+/// straight to `handle`. Checking only where the action is resolved makes
+/// the guarantee a property of today's call graph rather than of the type.
+#[test]
+fn a_handed_in_open_url_is_checked_before_it_becomes_a_signal() {
+    let stream = r#"[
+        {"version":"v0.9","createSurface":{"surfaceId":"s","catalogId":"basic"}},
+        {"version":"v0.9","updateComponents":{"surfaceId":"s","components":[
+            {"id":"root","component":"Text","text":"hi"}
+        ]}}
+    ]"#;
+    for url in [
+        "file:///etc/passwd",
+        "javascript:alert(1)",
+        "mailto:a@example.com?attach=/etc/passwd",
+        "mailto:a@example.com?%61ttach=/etc/passwd",
+    ] {
+        let mut client = apply(stream);
+        let surface = client.surface_mut("s").expect("surface");
+        let signals = surface.handle(A2uiMsg::OpenUrl(url.to_owned()));
+        assert!(
+            signals.is_empty(),
+            "{url} reached the host as {signals:?}, but the signal promises a \
+             scheme the host may launch"
+        );
+        assert!(
+            surface
+                .notes()
+                .iter()
+                .any(|n| n.kind == NoteKind::BlockedUrlScheme),
+            "refusing {url} silently is the failure this crate exists not to have, \
+             got: {:?}",
+            surface.notes()
+        );
+    }
+}
+
 /// One cause, one diagnosis. A blocked scheme records why the control is
 /// dead; the generic "no action it can carry out" note is a vaguer
 /// restatement of the same fact and must not accompany it.

--- a/fenestra-a2ui/tests/robustness.rs
+++ b/fenestra-a2ui/tests/robustness.rs
@@ -689,6 +689,13 @@ fn open_url_refuses_mailto_fields_that_are_not_plainly_safe() {
         // finite list of these, which is the whole argument for an allowlist.
         "mailto:attacker@example.com?x-mozilla-attach=/etc/passwd",
         "mailto:attacker@example.com?attachurl=file:///etc/passwd",
+        // Allowlisting the *name* is only half of it. RFC 6068 §7 warns
+        // that a client writing hfvalues into headers without sanitizing
+        // can be made to emit fields the URL never listed, so a decoded CR
+        // or LF inside a permitted field smuggles one in behind it — the
+        // encoded-value twin of the encoded-name hole above.
+        "mailto:victim@example.com?subject=Hi%0D%0Aattach=/Users/u/.ssh/id_rsa",
+        "mailto:victim@example.com?body=hello%0Abcc=attacker@example.com",
     ] {
         let stream = format!(
             r#"[

--- a/fenestra-a2ui/tests/robustness.rs
+++ b/fenestra-a2ui/tests/robustness.rs
@@ -812,6 +812,49 @@ fn a_handed_in_open_url_is_checked_before_it_becomes_a_signal() {
     }
 }
 
+/// The public checker is the renderer's whole rule, not the scheme half.
+///
+/// `OPENABLE_SCHEMES` is public and `is_openable` was not, which left a
+/// host re-validating a replayed URL with the only tool it had — scheme
+/// membership — and accepting exactly the strings the renderer refuses.
+#[test]
+fn the_public_url_check_matches_what_the_renderer_does() {
+    for url in [
+        "https://a2ui.org/spec",
+        "http://localhost:8080/preview",
+        "mailto:someone@example.com",
+        "mailto:someone@example.com?subject=Hi&body=there",
+    ] {
+        assert!(
+            fenestra_a2ui::is_openable_url(url),
+            "{url} is an ordinary link the renderer opens"
+        );
+    }
+    for url in [
+        "file:///etc/passwd",
+        "javascript:alert(1)",
+        "/etc/passwd",
+        "mailto:a@example.com?attach=/etc/passwd",
+        "mailto:a@example.com?%61ttach=/etc/passwd",
+        "mailto:a@example.com?subject=Hi%0D%0Aattach=/etc/passwd",
+    ] {
+        assert!(
+            !fenestra_a2ui::is_openable_url(url),
+            "{url} must be refused"
+        );
+        // And the trap the export exists to close: a scheme test alone
+        // accepts the mailto cases above, which is why a host must not
+        // re-derive this from OPENABLE_SCHEMES.
+        let scheme_only = fenestra_a2ui::OPENABLE_SCHEMES
+            .iter()
+            .any(|s| url.starts_with(&format!("{s}:")));
+        assert!(
+            !scheme_only || url.starts_with("mailto:"),
+            "{url} should not have passed a scheme-only test"
+        );
+    }
+}
+
 /// One cause, one diagnosis. A blocked scheme records why the control is
 /// dead; the generic "no action it can carry out" note is a vaguer
 /// restatement of the same fact and must not accompany it.


### PR DESCRIPTION
An adversarial pass over the A2UI renderer. Four findings; the one that
matters was not the one the pass went looking for.

## Rendering aborted the process at seven levels of nesting

`render_by_id -> render_component -> children_of -> render_by_id` is a
recursive cycle, so `render_component`'s stack frame is paid once per level
of component nesting. It was a single `match` over all nineteen component
kinds, and an unoptimized build gives such a frame room for every arm's
locals at once — arms do not share slots without optimization. Every level
therefore cost what the *largest* arm needed, and the largest arms
(`ChoicePicker`, `Slider`, `DateTimeInput`) are leaves that cannot appear on
the recursive path at all.

Measured on a 2 MiB stack — the `std::thread` and tokio blocking-pool
default, which is what the MCP server renders on — a strictly linear chain
of `Column`s overflowed at **seven** levels. `MAX_DEPTH` permits sixteen.

Seven is not an attack. A Card inside a List inside a Tab is already half of
it. And a stack overflow aborts rather than unwinds, so this was `SIGABRT`
for the whole server from about seven hundred bytes of JSON — uncatchable,
with no note and no error for a caller to see. Reachable from the MCP
`render_a2ui` tool, the CLI, and any live host.

`render_component` now holds only the kinds that recurse; every leaf kind
moved to `render_leaf`, which is `#[inline(never)]` so its locals get one
frame at the bottom of the recursion instead of a share of every level.

`MAX_DEPTH`'s own doc reasoned about the *element tree* it produces staying
inside `fenestra_core::MAX_TREE_DEPTH` — true, and silent about the
renderer's own recursion, which is where the cost was. `MAX_TREE_DEPTH` was
measured against a 2 MiB stack; this cap was derived from it without
inheriting the measurement.

## One budget, or the bound is not a bound

`children_of` charged template expansions to a render-wide budget and static
child lists to nothing at all — so the cheaper amplifier was the unbounded
one, since a static list needs no data model to expand against. Three
`Column`s naming the next one fifty times is 127 551 components from a
kilobyte of JSON; cycle detection does not fire (distinct id per level) and
the framework guards tree *depth*, never breadth.

Both arms now draw on one `MAX_RENDERED_CHILDREN` through
`Ctx::take_children`. Two counters can be played against each other by
alternating the kinds of child list, which is what the third test pins.

## An allowlist, or you are enumerating the attacker's options

`mailto:` URLs were checked against a blocklist of `attach` and
`attachment`. RFC 6068 writes `hfname` as `*qchar` with `pct-encoded` among
the `qchar`s, so a conforming client decodes the name before acting on it:
`%61ttach=` arrives as `attach=` and matched neither entry — nor did any
vendor spelling (`x-mozilla-attach`) nobody had enumerated. The check now
percent-decodes and compares against the fields a generated link
legitimately needs. Same argument `OPENABLE_SCHEMES` already makes one layer
out.

## A guarantee at one call site is a property of the call graph

`A2uiSignal::OpenUrl` documents that its URL is safe to hand to a platform
opener, but the check lived only where the renderer resolved an action —
and `A2uiMsg::OpenUrl` is a public variant a host can build, replay from a
log, or round-trip through its own message type. `Surface::handle`
re-checks it, so the promise belongs to the type.

## Tests

Six new tests, each of which fails on the parent commit:

- `renders_at_the_full_depth_cap` — a linear chain at `MAX_DEPTH`, on an
  explicitly 2 MiB thread (the harness's own main thread is 8 MiB and would
  have hidden the bug for another four levels). Aborts the test process
  before this change.
- `static_children_cannot_multiply_without_bound` — wide and shallow on
  purpose; nesting it deeper would trip the depth bug instead and prove
  nothing about the budget.
- `the_child_budget_is_shared_between_static_and_template_children`
- `open_url_refuses_mailto_fields_that_are_not_plainly_safe`
- `open_url_still_composes_ordinary_mail` — the allowlist has to not break
  ordinary mail links, or it just gets removed later.
- `a_handed_in_open_url_is_checked_before_it_becomes_a_signal`

## What was verified, and what was not

Verified locally: `cargo fmt --all --check` clean, and the full
`fenestra-a2ui` suite green (unit, amplification, robustness, validation,
interaction, conformance, catalog goldens, doc tests).

**Not run locally:** `cargo clippy --workspace --all-targets -D warnings`
and `cargo test --workspace`, and no headless renders of the flagship
examples. The machine was down to ~2 GiB free and a full workspace test
build is ~16 GiB here, so running them risked an unrecoverable ENOSPC. CI
covers all of it on macOS/Metal and Linux/lavapipe — please treat CI as the
gate on this one rather than my local run.

Also unverified: whether the stack overflow reproduces in a release build.
Frames are much smaller with optimization, so the safe depth is higher
there; the abort is confirmed for debug/test builds, which is what CI and
every downstream `cargo test` use.
