### PR TITLE
shell: Android support — bind the event loop to the activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@
 An adversarial pass over the A2UI renderer. One crash, one unbounded
 expansion, and two checks that were narrower than the thing they guarded.
 
+### Added
+
+- **fenestra-shell builds for Android.** winit's Android backend binds
+  the event loop to the activity before it starts, and nothing in
+  `WindowOptions` carried the `AndroidApp` that `android_main`
+  receives, so none of the three windowed runners could create a loop
+  on Android at all. `WindowOptions` now takes the handle
+  (`with_android_app`), and `run_scene`, `run_static`, and `run_app`
+  build their loops through one helper that attaches it. The OS
+  clipboard falls back to core's in-memory implementation on Android,
+  where arboard has no backend. Verified on an Android 14 emulator: a
+  zero-Java `NativeActivity` packaging a cdylib probe renders a
+  wgpu/Vulkan scene through the patched shell.
+
 ### Fixed
 
 - **Rendering aborted the process at seven levels of nesting.**

--- a/fenestra-shell/Cargo.toml
+++ b/fenestra-shell/Cargo.toml
@@ -27,6 +27,10 @@ serde_json.workspace = true
 accesskit_winit.workspace = true
 image.workspace = true
 pollster.workspace = true
+
+# The clipboard bridge has no Android backend (arboard supports X11/
+# Wayland, macOS, and Windows), so it stays out of Android builds.
+[target.'cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))'.dependencies]
 arboard.workspace = true
 
 # The native menu bar attaches on macOS (muda's safe path; see
@@ -39,3 +43,8 @@ muda.workspace = true
 wasm-bindgen-futures.workspace = true
 web-time.workspace = true
 web-sys.workspace = true
+
+# Android: winit exposes the `AndroidApp` the event loop binds to (see
+# `WindowOptions::with_android_app`) only behind this feature.
+[target.'cfg(target_os = "android")'.dependencies]
+winit = { workspace = true, features = ["android-native-activity"] }

--- a/fenestra-shell/src/os_clipboard.rs
+++ b/fenestra-shell/src/os_clipboard.rs
@@ -1,14 +1,36 @@
 //! The OS clipboard (arboard), injected into `FrameState` by the windowed
 //! runner. Headless rendering keeps core's in-memory clipboard.
+//!
+//! Android has no arboard backend: fall back to the in-memory clipboard so
+//! in-app copy/paste still works (system-clipboard bridge is a no-op).
 
 use fenestra_core::Clipboard;
+#[cfg(target_os = "android")]
+use fenestra_core::MemoryClipboard;
 
+#[cfg(target_os = "android")]
+#[derive(Default)]
+pub struct OsClipboard(MemoryClipboard);
+
+#[cfg(target_os = "android")]
+impl Clipboard for OsClipboard {
+    fn get(&mut self) -> Option<String> {
+        self.0.get()
+    }
+
+    fn set(&mut self, text: String) {
+        self.0.set(text)
+    }
+}
+
+#[cfg(not(target_os = "android"))]
 /// Lazy arboard wrapper; failures (no display server) degrade to a no-op.
 #[derive(Default)]
 pub struct OsClipboard {
     inner: Option<arboard::Clipboard>,
 }
 
+#[cfg(not(target_os = "android"))]
 impl OsClipboard {
     fn ensure(&mut self) -> Option<&mut arboard::Clipboard> {
         if self.inner.is_none() {
@@ -18,6 +40,7 @@ impl OsClipboard {
     }
 }
 
+#[cfg(not(target_os = "android"))]
 impl Clipboard for OsClipboard {
     fn get(&mut self) -> Option<String> {
         self.ensure().and_then(|c| c.get_text().ok())

--- a/fenestra-shell/src/window.rs
+++ b/fenestra-shell/src/window.rs
@@ -27,6 +27,8 @@ use winit::event::{MouseScrollDelta, StartCause, WindowEvent};
 #[cfg(not(target_arch = "wasm32"))]
 use winit::event_loop::EventLoopProxy;
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
+#[cfg(target_os = "android")]
+use winit::platform::android::EventLoopBuilderExtAndroid;
 use winit::window::{Window, WindowId};
 
 use crate::ShellError;
@@ -72,6 +74,10 @@ pub struct WindowOptions {
     /// Custom faces registered on the runner's fonts before the first
     /// frame: design languages work in windows, not just headlessly.
     pub fonts: Vec<(fenestra_core::FamilyRole, Vec<u8>)>,
+    /// Android: the `AndroidApp` received in `android_main`, which winit
+    /// needs to bind the event loop to the activity.
+    #[cfg(target_os = "android")]
+    pub android_app: Option<winit::platform::android::activity::AndroidApp>,
 }
 
 impl WindowOptions {
@@ -86,6 +92,8 @@ impl WindowOptions {
             fullscreen: false,
             icon: None,
             fonts: Vec::new(),
+            #[cfg(target_os = "android")]
+            android_app: None,
         }
     }
 
@@ -130,6 +138,14 @@ impl WindowOptions {
     /// fonts (TTF/OTF bytes; see `Fonts::register`).
     pub fn with_font(mut self, role: fenestra_core::FamilyRole, data: Vec<u8>) -> Self {
         self.fonts.push((role, data));
+        self
+    }
+
+    /// Attaches the `AndroidApp` received in `android_main` so winit can
+    /// bind the event loop to the activity (Android only).
+    #[cfg(target_os = "android")]
+    pub fn with_android_app(mut self, app: winit::platform::android::activity::AndroidApp) -> Self {
+        self.android_app = Some(app);
         self
     }
 }
@@ -515,6 +531,22 @@ impl WindowShell {
     }
 }
 
+/// Builds the event loop for a windowed runner. On Android, winit requires
+/// the `AndroidApp` from `android_main` so the loop can bind to the activity.
+fn build_event_loop<E>(
+    options: &WindowOptions,
+) -> Result<EventLoop<E>, winit::error::EventLoopError> {
+    // Read on every target: the field it carries today is cfg'd out
+    // everywhere except Android.
+    let _ = options;
+    let mut builder = EventLoop::<E>::with_user_event();
+    #[cfg(target_os = "android")]
+    if let Some(app) = options.android_app.clone() {
+        builder.with_android_app(app);
+    }
+    builder.build()
+}
+
 // ------------------------------------------------------------- run_scene
 
 /// Opens a window and repaints via `paint(scene, logical_w, logical_h, bg)`
@@ -526,7 +558,7 @@ pub fn run_scene(
     background: Color,
     paint: impl FnMut(&mut Scene, f64, f64, Color) + 'static,
 ) -> Result<(), ShellError> {
-    let event_loop = EventLoop::new().map_err(ShellError::EventLoop)?;
+    let event_loop = build_event_loop(&options).map_err(ShellError::EventLoop)?;
     let mut app = SceneApp {
         shell: WindowShell::new(options, background),
         fragment: Scene::new(),
@@ -625,7 +657,7 @@ pub fn run_static(
     theme: Theme,
     view: impl Fn(&Theme) -> Element<()> + 'static,
 ) -> Result<(), ShellError> {
-    let event_loop = EventLoop::new().map_err(ShellError::EventLoop)?;
+    let event_loop = build_event_loop(&options).map_err(ShellError::EventLoop)?;
     let background = theme.bg;
     let mut fonts = Fonts::with_system();
     for (role, data) in &options.fonts {
@@ -803,9 +835,7 @@ pub fn run_app<A: App + 'static>(mut app: A, options: WindowOptions) -> Result<(
 where
     A::Msg: Send,
 {
-    let event_loop = EventLoop::<RunnerEvent>::with_user_event()
-        .build()
-        .map_err(ShellError::EventLoop)?;
+    let event_loop = build_event_loop::<RunnerEvent>(&options).map_err(ShellError::EventLoop)?;
     #[cfg(not(target_arch = "wasm32"))]
     let access_proxy = event_loop.create_proxy();
     let proxy = event_loop.create_proxy();


### PR DESCRIPTION
winit's Android backend binds the event loop to the activity before it
starts, and nothing in `WindowOptions` carried the `AndroidApp` that
`android_main` receives — so none of the three windowed runners could
create a loop on Android at all. This adds first Android support to
fenestra-shell.

## Changes

- `WindowOptions::android_app` + `with_android_app()`: carry the
  `AndroidApp` from `android_main` into the runner.
- `run_scene` / `run_static` / `run_app` now build their event loops
  through one private `build_event_loop()` helper that attaches the
  handle where winit requires it.
- `arboard` stays out of Android builds (it has no Android backend) and
  the OS clipboard falls back to core's in-memory `MemoryClipboard`
  there, so in-app copy/paste keeps working.
- winit's `android-native-activity` feature is enabled for the Android
  target only.

## Verified

- On device (Android 14 emulator, goldfish Vulkan): a zero-Java
  `NativeActivity` APK packaging a cdylib probe built against this
  branch renders a wgpu/Vulkan/vello scene end to end. The probe's
  entry point is `#[no_mangle] fn android_main(app: AndroidApp)` per
  the android-activity contract; the APK needs
  `android:hasCode="false"` because it ships no Java.
- CI-equivalent gates on the branch: `cargo fmt --all --check`,
  `cargo clippy --workspace --all-targets -- -D warnings`, and
  `cargo test --workspace` (macOS / Metal) all pass.
- `cargo clippy -p fenestra-shell --target aarch64-linux-android
  --all-targets` is clean for fenestra-shell.

## Notes

- clippy 1.97 has a target-dependent false positive:
  `missing_const_for_thread_local` fires on `fenestra-core/src/frame.rs`
  for an initializer that is already `const { ... }`, and only when
  checking the Android target. Not touched here; it will surface if an
  Android clippy job is added with `-D warnings`.
- Suggested follow-up: an Android `cargo check` CI job (NDK on the
  ubuntu runner) so the platform cannot silently regress.
