### PR TITLE
core: element gesture events — wheel, drag events, pinch

### DIFF
--- a/fenestra-core/src/element.rs
+++ b/fenestra-core/src/element.rs
@@ -4,7 +4,7 @@
 
 use peniko::Color;
 
-use crate::events::KeyInput;
+use crate::events::{DragEvent, KeyInput, PinchEvent, WheelEvent};
 use crate::style::{Length, Paint, Style, TextAlign, TextWrap, ThemedFn, Transition};
 use crate::theme::Theme;
 use crate::tokens::{ShadowToken, TextSize, Weight};
@@ -14,6 +14,12 @@ pub(crate) type TypeAheadFn<Msg> = Box<dyn Fn(&str) -> Option<Msg>>;
 pub(crate) type KeyFn<Msg> = Box<dyn Fn(&KeyInput) -> Option<Msg>>;
 /// Maps a pointer position (as fractions of the element rect) to a message.
 pub(crate) type DragFn<Msg> = Box<dyn Fn(f32, f32) -> Option<Msg>>;
+/// Maps a wheel/trackpad gesture to an optional message.
+pub(crate) type WheelFn<Msg> = Box<dyn Fn(WheelEvent) -> Option<Msg>>;
+/// Maps a press or captured drag, with position and modifiers, to a message.
+pub(crate) type DragEventFn<Msg> = Box<dyn Fn(DragEvent) -> Option<Msg>>;
+/// Maps a trackpad magnification gesture to an optional message.
+pub(crate) type PinchFn<Msg> = Box<dyn Fn(PinchEvent) -> Option<Msg>>;
 /// Maps a recognized [`SwipeDir`] to a message.
 pub(crate) type SwipeFn<Msg> = Box<dyn Fn(SwipeDir) -> Msg>;
 /// Maps the edited text to a message.
@@ -616,6 +622,12 @@ pub struct Element<Msg> {
     /// that drove [`Self::on_drag`] ended). Only meaningful alongside
     /// `on_drag`; used for drag lifecycles like column-resize commit.
     pub(crate) on_drag_end: Option<Msg>,
+    /// Wheel / trackpad deltas over this element, before scroll routing.
+    pub(crate) on_wheel: Option<WheelFn<Msg>>,
+    /// Presses and captured drags, with unclamped position and modifiers.
+    pub(crate) on_drag_event: Option<DragEventFn<Msg>>,
+    /// Trackpad magnification over this element.
+    pub(crate) on_pinch: Option<PinchFn<Msg>>,
     /// Fired when a press-drag-release on this element is recognized as a swipe
     /// (a fast flick past a small distance), with the dominant [`SwipeDir`].
     pub(crate) on_swipe: Option<SwipeFn<Msg>>,
@@ -692,6 +704,9 @@ impl<Msg> Element<Msg> {
             on_key: None,
             on_drag: None,
             on_drag_end: None,
+            on_wheel: None,
+            on_drag_event: None,
+            on_pinch: None,
             on_swipe: None,
             on_input: None,
             on_close: None,
@@ -766,6 +781,7 @@ impl<Msg> Element<Msg> {
         !self.disabled
             && (self.on_click.is_some()
                 || self.on_drag.is_some()
+                || self.on_drag_event.is_some()
                 || self.on_swipe.is_some()
                 || self.focusable
                 || self.selectable)
@@ -934,6 +950,43 @@ impl<Msg> Element<Msg> {
     /// rect on both axes.
     pub fn on_drag(mut self, f: impl Fn(f32, f32) -> Option<Msg> + 'static) -> Self {
         self.on_drag = Some(Box::new(f));
+        self
+    }
+
+    /// Maps wheel and trackpad deltas over this element to messages, in
+    /// logical pixels and winit's sign convention (positive `dy` moves the
+    /// content down). Offered along the hit chain deepest-first, *before*
+    /// the event routes to the nearest scroll container: return `Some` to
+    /// consume it, `None` to let scrolling have it. A pan/zoom canvas wants
+    /// this — it owns its own camera and is not a scroll container.
+    pub fn on_wheel(mut self, f: impl Fn(WheelEvent) -> Option<Msg> + 'static) -> Self {
+        self.on_wheel = Some(Box::new(f));
+        self
+    }
+
+    /// Like [`Self::on_drag`], but the callback receives a [`DragEvent`]:
+    /// the pointer in element-local logical pixels, *unclamped*, plus the
+    /// held modifiers. `on_drag`'s fractions are clamped to the element, so
+    /// a gesture that leaves it stops tracking — fine for a slider, fatal
+    /// for a canvas whose nodes are a few pixels wide when zoomed out. The
+    /// two can coexist on one element; both fire.
+    ///
+    /// Capture and [`Self::on_drag_end`] work exactly as they do for
+    /// `on_drag`.
+    pub fn on_drag_event(mut self, f: impl Fn(DragEvent) -> Option<Msg> + 'static) -> Self {
+        self.on_drag_event = Some(Box::new(f));
+        self
+    }
+
+    /// Trackpad magnification (macOS and iOS only; nothing else reports it).
+    /// Offered deepest-first along the hit chain, exactly once per element —
+    /// unlike [`Self::on_wheel`] there is no fallback consumer, so returning
+    /// `None` simply drops the gesture.
+    ///
+    /// A pinch is not a ctrl+wheel. Handle both if you want zoom to work with
+    /// a trackpad *and* a mouse.
+    pub fn on_pinch(mut self, f: impl Fn(PinchEvent) -> Option<Msg> + 'static) -> Self {
+        self.on_pinch = Some(Box::new(f));
         self
     }
 
@@ -2235,6 +2288,18 @@ impl<Msg: 'static> Element<Msg> {
                 Box::new(move |x: f32, y: f32| d(x, y).map(&f)) as DragFn<B>
             }),
             on_drag_end: self.on_drag_end.map(&f),
+            on_wheel: self.on_wheel.map(|w| {
+                let f = f.clone();
+                Box::new(move |e: WheelEvent| w(e).map(&f)) as WheelFn<B>
+            }),
+            on_drag_event: self.on_drag_event.map(|d| {
+                let f = f.clone();
+                Box::new(move |e: DragEvent| d(e).map(&f)) as DragEventFn<B>
+            }),
+            on_pinch: self.on_pinch.map(|p| {
+                let f = f.clone();
+                Box::new(move |e: PinchEvent| p(e).map(&f)) as PinchFn<B>
+            }),
             on_swipe: self.on_swipe.map(|s| {
                 let f = f.clone();
                 Box::new(move |d: SwipeDir| f(s(d))) as SwipeFn<B>

--- a/fenestra-core/src/events.rs
+++ b/fenestra-core/src/events.rs
@@ -46,6 +46,113 @@ pub enum Key {
     Char(char),
 }
 
+/// The modifier keys held when a gesture fired, as last reported by
+/// [`InputEvent::Modifiers`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Mods {
+    /// Shift held.
+    pub shift: bool,
+    /// Control held. Browsers deliver pinch-zoom as ctrl+wheel, so this is
+    /// the conventional zoom modifier.
+    pub ctrl: bool,
+    /// Alt/Option held.
+    pub alt: bool,
+    /// Command (macOS) / Windows key held.
+    pub meta: bool,
+}
+
+/// A wheel or trackpad gesture delivered to [`Element::on_wheel`].
+///
+/// [`Element::on_wheel`]: crate::Element::on_wheel
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct WheelEvent {
+    /// Horizontal delta in logical px (winit's convention: positive `dx`
+    /// moves the content right).
+    pub dx: f32,
+    /// Vertical delta in logical px (positive `dy` moves the content down).
+    pub dy: f32,
+    /// Pointer x in logical px from the element's left edge, measured in the
+    /// element's own untransformed layout space — the space `on_drag` takes
+    /// its fractions in. A pan/zoom canvas feeds this to `Camera::to_world`
+    /// to zoom about the cursor instead of the viewport center.
+    pub x: f32,
+    /// Pointer y in logical px from the element's top edge.
+    pub y: f32,
+    /// Modifier keys held — what separates zooming from panning.
+    ///
+    /// ctrl+wheel is the conventional zoom gesture everywhere, and is how a
+    /// browser reports a pinch. A *native* trackpad pinch is a separate
+    /// event: see [`InputEvent::Pinch`] and [`Element::on_pinch`].
+    ///
+    /// [`Element::on_pinch`]: crate::Element::on_pinch
+    pub mods: Mods,
+}
+
+/// A trackpad magnification gesture delivered to [`Element::on_pinch`].
+///
+/// [`Element::on_pinch`]: crate::Element::on_pinch
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PinchEvent {
+    /// Change in scale since the last event: positive magnifies. Apply it as
+    /// `zoom * (1.0 + delta)`, which is winit's own convention. Guaranteed
+    /// finite — the runner drops the NaN deltas the OS can emit.
+    pub delta: f32,
+    /// Pointer x in logical px from the element's left edge, in its own
+    /// untransformed layout space. A canvas zooms about this point.
+    pub x: f32,
+    /// Pointer y in logical px from the element's top edge.
+    pub y: f32,
+    /// Whether the gesture has just begun, is continuing, or has ended.
+    pub phase: GesturePhase,
+}
+
+/// Where in its life a continuous gesture is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GesturePhase {
+    Started,
+    Changed,
+    Ended,
+}
+
+/// A pointer press or captured drag delivered to [`Element::on_drag_event`].
+///
+/// [`Element::on_drag_event`]: crate::Element::on_drag_event
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DragEvent {
+    /// Pointer x in logical px from the element's left edge, in its own
+    /// untransformed layout space. Unlike [`Element::on_drag`]'s fractions
+    /// this is *not* clamped to the element, so a gesture that leaves the
+    /// element keeps tracking — what a canvas needs, and what a slider does
+    /// not.
+    ///
+    /// [`Element::on_drag`]: crate::Element::on_drag
+    pub x: f32,
+    /// Pointer y in logical px from the element's top edge.
+    pub y: f32,
+    /// Modifier keys held, for shift-to-extend and friends.
+    pub mods: Mods,
+}
+
+/// The modifiers as the dispatcher currently knows them.
+fn mods_of(state: &FrameState) -> Mods {
+    Mods {
+        shift: state.mods.0,
+        ctrl: state.mods.1,
+        alt: state.mods.2,
+        meta: state.mods.3,
+    }
+}
+
+/// A screen point in an element's own untransformed layout space, in logical
+/// px from its top-left — the mapping [`Frame::fraction_in`] uses, without
+/// the clamp. `None` when the id is not in this frame.
+fn local_px(frame: &Frame, id: WidgetId, point: Point) -> Option<(f32, f32)> {
+    let rect = frame.rect_of(id)?;
+    let p = frame.to_layout_point(id, point)?;
+    #[expect(clippy::cast_possible_truncation, reason = "logical pixel coordinates")]
+    Some(((p.x - rect.x0) as f32, (p.y - rect.y0) as f32))
+}
+
 /// A key press with modifiers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct KeyInput {
@@ -103,6 +210,16 @@ pub enum InputEvent {
         dx: f32,
         /// Vertical delta in logical px.
         dy: f32,
+    },
+    /// Trackpad magnification (macOS/iOS only; other platforms never send
+    /// it). Distinct from [`Self::Wheel`]: a pinch carries a *scale* delta,
+    /// not a scroll distance, and no amount of modifier convention makes the
+    /// two the same gesture.
+    Pinch {
+        /// Change in scale since the last event; positive magnifies.
+        delta: f32,
+        /// Gesture lifecycle.
+        phase: GesturePhase,
     },
     /// Modifier keys changed (runners forward this so pointer gestures
     /// can honor Shift — e.g. shift-click selection extension).
@@ -487,11 +604,23 @@ pub fn dispatch<Msg: Clone>(
                             state.static_sel = Some((active, sel, true));
                             out.redraw = true;
                         }
-                    } else if let Some(f) = &el.on_drag
-                        && let Some((fx, fy)) = frame.fraction_in(active, point)
-                        && let Some(msg) = f(fx, fy)
-                    {
-                        out.msgs.push(msg);
+                    } else {
+                        if let Some(f) = &el.on_drag
+                            && let Some((fx, fy)) = frame.fraction_in(active, point)
+                            && let Some(msg) = f(fx, fy)
+                        {
+                            out.msgs.push(msg);
+                        }
+                        if let Some(f) = &el.on_drag_event
+                            && let Some((x, y)) = local_px(frame, active, point)
+                            && let Some(msg) = f(DragEvent {
+                                x,
+                                y,
+                                mods: mods_of(state),
+                            })
+                        {
+                            out.msgs.push(msg);
+                        }
                     }
                 }
                 out.cursor = Some(cursor_of(&handlers, &[active]));
@@ -642,11 +771,23 @@ pub fn dispatch<Msg: Clone>(
                             );
                             state.static_sel = Some((id, sel, true));
                         }
-                    } else if let Some(f) = &el.on_drag
-                        && let Some((fx, fy)) = frame.fraction_in(id, point)
-                        && let Some(msg) = f(fx, fy)
-                    {
-                        out.msgs.push(msg);
+                    } else {
+                        if let Some(f) = &el.on_drag
+                            && let Some((fx, fy)) = frame.fraction_in(id, point)
+                            && let Some(msg) = f(fx, fy)
+                        {
+                            out.msgs.push(msg);
+                        }
+                        if let Some(f) = &el.on_drag_event
+                            && let Some((x, y)) = local_px(frame, id, point)
+                            && let Some(msg) = f(DragEvent {
+                                x,
+                                y,
+                                mods: mods_of(state),
+                            })
+                        {
+                            out.msgs.push(msg);
+                        }
                     }
                 }
                 out.redraw = true;
@@ -762,7 +903,7 @@ pub fn dispatch<Msg: Clone>(
                 // never fires here.
                 if let Some(el) = handlers.get(active)
                     && !el.disabled
-                    && el.on_drag.is_some()
+                    && (el.on_drag.is_some() || el.on_drag_event.is_some())
                     && let Some(msg) = &el.on_drag_end
                 {
                     out.msgs.push(msg.clone());
@@ -795,9 +936,49 @@ pub fn dispatch<Msg: Clone>(
                 );
             }
         }
+        InputEvent::Pinch { delta, phase } => {
+            // Same deepest-first offer as the wheel, but with no fallback:
+            // nothing else in the framework consumes a magnification.
+            if let Some((x, y)) = state.pointer {
+                let p = Point::new(f64::from(x), f64::from(y));
+                for id in frame.hit_chain(p).into_iter().rev() {
+                    if let Some(el) = handlers.get(id)
+                        && !el.disabled
+                        && let Some(f) = &el.on_pinch
+                    {
+                        let (x, y) = local_px(frame, id, p).unwrap_or((0.0, 0.0));
+                        if let Some(msg) = f(PinchEvent { delta, x, y, phase }) {
+                            out.msgs.push(msg);
+                            out.redraw = true;
+                        }
+                        break;
+                    }
+                }
+            }
+        }
         InputEvent::Wheel { dx, dy } => {
             if let Some((x, y)) = state.pointer {
                 let p = Point::new(f64::from(x), f64::from(y));
+                // An `on_wheel` element gets first refusal, deepest-first, so a
+                // pan/zoom canvas nested in a scrolling pane keeps its own
+                // gesture. Returning `None` declines and falls through to the
+                // scroll routing below — the same "handled?" contract as
+                // `on_key` and `on_drag`.
+                let mods = mods_of(state);
+                for id in frame.hit_chain(p).into_iter().rev() {
+                    if let Some(el) = handlers.get(id)
+                        && !el.disabled
+                        && let Some(f) = &el.on_wheel
+                    {
+                        let (x, y) = local_px(frame, id, p).unwrap_or((0.0, 0.0));
+                        if let Some(msg) = f(WheelEvent { dx, dy, x, y, mods }) {
+                            out.msgs.push(msg);
+                            out.redraw = true;
+                            return out;
+                        }
+                        break;
+                    }
+                }
                 // dy and dx route to the nearest scroller on their OWN axis —
                 // which may be different containers (e.g. a horizontal pane
                 // nested in a vertical one).

--- a/fenestra-core/src/lib.rs
+++ b/fenestra-core/src/lib.rs
@@ -50,7 +50,10 @@ pub use element::{
     VirtualData, col, div, divider, image_from_data, image_payload, image_rgba8, path, raw_input,
     raw_text_area, responsive, responsive_hinted, rich_text, row, spacer, span, stack, text,
 };
-pub use events::{Dispatch, InputEvent, Key, KeyInput, click_msg_of, dispatch, refresh_hover};
+pub use events::{
+    Dispatch, DragEvent, GesturePhase, InputEvent, Key, KeyInput, Mods, PinchEvent, WheelEvent,
+    click_msg_of, dispatch, refresh_hover,
+};
 pub use frame::{AccessNode, Frame, TextLegibility, build_frame, build_scene, frame_epoch};
 pub use frame_state::FrameState;
 pub use i18n::{Catalog, Locale};

--- a/fenestra-shell/src/harness.rs
+++ b/fenestra-shell/src/harness.rs
@@ -28,8 +28,8 @@ use std::sync::{Arc, Mutex, PoisonError};
 use std::collections::HashMap;
 
 use fenestra_core::{
-    AccessNode, App, Element, Frame, FrameState, InputEvent, KeyInput, MAIN_WINDOW, Proxy, Query,
-    Theme, build_frame, dispatch,
+    AccessNode, App, Element, Frame, FrameState, GesturePhase, InputEvent, KeyInput, MAIN_WINDOW,
+    Proxy, Query, Theme, build_frame, dispatch,
 };
 use image::RgbaImage;
 
@@ -486,6 +486,28 @@ where
     pub fn wheel_xy(&mut self, q: &Query, dx: f32, dy: f32) {
         self.hover(q);
         self.input(InputEvent::Wheel { dx, dy });
+    }
+
+    /// Pinches over the matched node: one `Started`, the `delta` as
+    /// `Changed`, then `Ended` — the shape the OS actually sends, so a
+    /// handler that keys off the phase is exercised.
+    ///
+    /// # Panics
+    /// If the query matches zero or several nodes.
+    pub fn pinch(&mut self, q: &Query, delta: f32) {
+        self.hover(q);
+        self.input(InputEvent::Pinch {
+            delta: 0.0,
+            phase: GesturePhase::Started,
+        });
+        self.input(InputEvent::Pinch {
+            delta,
+            phase: GesturePhase::Changed,
+        });
+        self.input(InputEvent::Pinch {
+            delta: 0.0,
+            phase: GesturePhase::Ended,
+        });
     }
 
     /// Advances the deterministic clock by `ms` milliseconds and

--- a/fenestra-shell/src/synthetic.rs
+++ b/fenestra-shell/src/synthetic.rs
@@ -1,7 +1,7 @@
 //! Synthetic event injection for headless testing: agents drive an [`App`]
 //! with scripted input and look at the resulting pixels.
 
-use fenestra_core::{App, InputEvent, KeyInput, Theme};
+use fenestra_core::{App, GesturePhase, InputEvent, KeyInput, Theme};
 use image::RgbaImage;
 
 /// A scripted input event for [`render_app`].
@@ -28,6 +28,14 @@ pub enum SyntheticEvent {
     Key(KeyInput),
     /// Commit text (M5).
     Text(String),
+    /// Trackpad magnification: `delta` is the change in scale, positive to
+    /// magnify. The windowed runner only ever produces this on macOS and iOS.
+    Pinch {
+        /// Change in scale since the last event.
+        delta: f32,
+        /// Gesture lifecycle.
+        phase: GesturePhase,
+    },
     /// Scroll (winit convention: positive `dy` moves content down, positive
     /// `dx` moves content right).
     Wheel {
@@ -56,6 +64,10 @@ impl From<&SyntheticEvent> for InputEvent {
             SyntheticEvent::Key(k) => Self::Key(*k),
             SyntheticEvent::Text(s) => Self::Text(s.clone()),
             SyntheticEvent::Wheel { dx, dy } => Self::Wheel { dx: *dx, dy: *dy },
+            SyntheticEvent::Pinch { delta, phase } => Self::Pinch {
+                delta: *delta,
+                phase: *phase,
+            },
             SyntheticEvent::Tab => Self::Tab,
             SyntheticEvent::ShiftTab => Self::ShiftTab,
             SyntheticEvent::Modifiers(shift, ctrl, alt, meta) => Self::Modifiers {

--- a/fenestra-shell/src/window.rs
+++ b/fenestra-shell/src/window.rs
@@ -13,8 +13,8 @@ use web_time::Instant;
 #[cfg(not(target_arch = "wasm32"))]
 use fenestra_core::Theme;
 use fenestra_core::{
-    App, Element, Fonts, FrameState, InputEvent, Key, KeyInput, build_frame, dispatch,
-    refresh_hover,
+    App, Element, Fonts, FrameState, GesturePhase, InputEvent, Key, KeyInput, build_frame,
+    dispatch, refresh_hover,
 };
 use kurbo::Point;
 use vello::peniko::Color;
@@ -23,7 +23,7 @@ use vello::wgpu::{self, CurrentSurfaceTexture};
 use vello::{AaConfig, AaSupport, RenderParams, Renderer, RendererOptions, Scene};
 use winit::application::ApplicationHandler;
 use winit::dpi::LogicalSize;
-use winit::event::{MouseScrollDelta, StartCause, WindowEvent};
+use winit::event::{MouseScrollDelta, StartCause, TouchPhase, WindowEvent};
 #[cfg(not(target_arch = "wasm32"))]
 use winit::event_loop::EventLoopProxy;
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
@@ -33,6 +33,26 @@ use crate::ShellError;
 
 /// One wheel "line" in logical pixels.
 pub(crate) const LINE_SCROLL_PX: f64 = 40.0;
+
+/// winit's touch phase as the framework's gesture lifecycle. A cancelled
+/// gesture ends like any other: an app that undid its in-progress effect on
+/// `Ended` would need a distinct variant, and nothing here does.
+pub(crate) fn gesture_phase(phase: TouchPhase) -> GesturePhase {
+    match phase {
+        TouchPhase::Started => GesturePhase::Started,
+        TouchPhase::Moved => GesturePhase::Changed,
+        TouchPhase::Ended | TouchPhase::Cancelled => GesturePhase::Ended,
+    }
+}
+
+/// A winit magnification delta as a finite `f32`, or `None`. winit documents
+/// this value as possibly NaN, and a NaN would poison an app's zoom for the
+/// rest of the session.
+pub(crate) fn pinch_delta(delta: f64) -> Option<f32> {
+    #[expect(clippy::cast_possible_truncation, reason = "scale deltas are small")]
+    let d = delta as f32;
+    d.is_finite().then_some(d)
+}
 
 /// Extracts `(dx, dy)` logical-pixel deltas from a winit wheel event, honoring
 /// the window scale for pixel deltas.
@@ -1616,6 +1636,18 @@ impl<A: App> AppRunner<A> {
                     },
                 );
             }
+            WindowEvent::PinchGesture { delta, phase, .. } => {
+                if let Some(delta) = pinch_delta(delta) {
+                    self.secondary_input_main(
+                        key,
+                        event_loop,
+                        InputEvent::Pinch {
+                            delta,
+                            phase: gesture_phase(phase),
+                        },
+                    );
+                }
+            }
             WindowEvent::KeyboardInput { event, .. }
                 if event.state == winit::event::ElementState::Pressed =>
             {
@@ -2029,6 +2061,17 @@ impl<A: App> ApplicationHandler<RunnerEvent> for AppRunner<A> {
                         dy: dy as f32,
                     },
                 );
+            }
+            WindowEvent::PinchGesture { delta, phase, .. } => {
+                if let Some(delta) = pinch_delta(delta) {
+                    self.input_main(
+                        event_loop,
+                        InputEvent::Pinch {
+                            delta,
+                            phase: gesture_phase(phase),
+                        },
+                    );
+                }
             }
             WindowEvent::KeyboardInput { event, .. }
                 if event.state == winit::event::ElementState::Pressed =>


### PR DESCRIPTION
Three gaps, one theme: the gesture plumbing does not carry enough to
drive a surface that owns its own camera instead of being a scroll
container.

1. `InputEvent::Wheel` routes only to the nearest scroll container.
   There is no `on_wheel` builder and no app-level raw-event hook, so a
   pan/zoom canvas never sees a wheel at all — no scroll-to-pan, no
   ctrl-scroll zoom.
2. `on_drag` reports the pointer as clamped 0..=1 fractions of the
   element rect, with no modifiers. Clamping is right for a slider and
   wrong for a canvas: a gesture that leaves the element stops tracking.
   Without modifiers there is no shift-to-extend.
3. `WindowEvent::PinchGesture` is not handled anywhere in the shell, so a
   real trackpad pinch is dropped on the floor.

## Changes

One coherent addition, six files across two crates (~345 lines).

**fenestra-core**

- `events.rs`: public `Mods`, `WheelEvent`, `DragEvent`, `PinchEvent`,
  `GesturePhase`; an `InputEvent::Pinch` variant; the `Wheel` arm now
  offers the gesture along the hit chain, deepest first, before the
  existing scroll routing; a matching `Pinch` arm; both `on_drag`
  dispatch sites also fire `on_drag_event`.
- `element.rs`: `Element::on_wheel`, `on_drag_event`, `on_pinch` (plus fn
  aliases, fields, defaults, and `map` arms); `on_drag_event` counts
  toward `takes_press` and the `on_drag_end` condition.
- `lib.rs`: re-exports.

**fenestra-shell**

- `window.rs`: `WindowEvent::PinchGesture` → `InputEvent::Pinch` in both
  window handlers, via a phase mapper and a NaN guard on the delta
  (winit documents the delta as possibly NaN, and a NaN would poison an
  app's zoom for the rest of the session). The `StaticApp` runner is left
  alone: it has no app to deliver to.
- `synthetic.rs` / `harness.rs`: `SyntheticEvent::Pinch` and
  `Harness::pinch(query, delta)`, which sends the Started/Changed/Ended
  sequence the OS actually produces, so the gesture is scriptable
  headlessly like every other input.

All three events carry the pointer in element-local logical pixels,
unclamped (a canvas zooms about the cursor and keeps tracking past the
window edge); wheel and drag also carry modifiers.

Returning `None` from `on_wheel` declines the gesture and falls through
to scroll routing — the same "handled?" contract as `on_key` and
`on_drag` — so a canvas nested in a scrolling pane keeps its own gesture
without breaking the pane. `on_drag` and `on_drag_event` fire together on
one element. `on_pinch` has no fallback consumer; declining drops it.

Platform note: winit emits `PinchGesture` only on macOS and iOS. On the
web a pinch already arrives as ctrl+wheel, which `on_wheel` handles; on
Windows and Linux there is no pinch to forward.

## Verified

On this branch, against current main:

- `cargo fmt -p fenestra-core -p fenestra-shell --check`
- `cargo clippy -p fenestra-core -p fenestra-shell --all-targets -- -D warnings`
- `cargo test -p fenestra-core -p fenestra-shell -p fenestra-kit` —
  641 passed, 0 failed

Also applies cleanly on top of #23 (the Android shell support), which
touches `window.rs` in a disjoint region.

## Motivation

Building an infinite canvas on fenestra 0.41 (agentic-graph) required
all three: scroll-to-pan, ctrl-scroll and trackpad-pinch zoom, and
unclamped drag tracking with shift-to-extend. This diff has lived as a
vendored fork with a standalone patch there until this lands; the fork
deletes when it does.
